### PR TITLE
Fix resolving queue URLs

### DIFF
--- a/src/components/Queues.ts
+++ b/src/components/Queues.ts
@@ -122,7 +122,7 @@ export class Queues extends Component<typeof COMPONENT_NAME, typeof COMPONENT_DE
         const queue = this.getComponent(id);
 
         const properties = queue.exposedVariables();
-        if (!has(properties, id)) {
+        if (!has(properties, property)) {
             throw new Error(
                 `\${${this.getName()}:${id}.${property}} does not exist. Properties available on \${${this.getName()}:${id}} are: ${Object.keys(
                     properties


### PR DESCRIPTION
While testing the plugin, I encountered a weird issue when trying to access the URL of Lift-created Queue.

> Cannot resolve variable at "provider.environment.QUEUE_URL": Error: ${queues:myQueue.queueUrl} does not exist. Properties available on ${queues:myQueue} are: queueArn, queueUrl.

AFAICT `resolveVariable` will get in this case the string `myQueue.queueUrl` then when splitting `id` will be `myQueue` and `property` will be `queueUrl`.

So `property` should be used instead of `id` to check if this is a supported URL.

As a **very dirty workaround**, I called my queue `queueUrl` and it works when using `${queues:queueUrl.queueUrl}` :joy:

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->
