### PR TITLE
Static website: upgrade to using cache policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2": "1.107",
         "@aws-cdk/aws-apigatewayv2-integrations": "1.107",
+        "@aws-cdk/aws-certificatemanager": "1.107",
         "@aws-cdk/aws-cloudfront": "1.107.0",
+        "@aws-cdk/aws-cloudfront-origins": "1.107",
         "@aws-cdk/aws-cloudwatch": "1.107.0",
         "@aws-cdk/aws-events": "1.107.0",
         "@aws-cdk/aws-iam": "1.107.0",
@@ -187,7 +189,6 @@
       "version": "1.107.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.107.0.tgz",
       "integrity": "sha512-pMeCF4CUOT0Zor7gbZF5NT54Fn50b+bTSXYTRzM9v8nXlIFpo3HJAsIpVJRGNnDdLwwEXXmRzgx7dIE4UVzouw==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.107.0",
         "@aws-cdk/aws-lambda": "1.107.0",
@@ -261,6 +262,30 @@
         "@aws-cdk/aws-lambda": "1.107.0",
         "@aws-cdk/aws-s3": "1.107.0",
         "@aws-cdk/aws-ssm": "1.107.0",
+        "@aws-cdk/core": "1.107.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudfront-origins": {
+      "version": "1.107.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront-origins/-/aws-cloudfront-origins-1.107.0.tgz",
+      "integrity": "sha512-NLqFPPdc35HRXJV+3sybx3UpAhVNpUUJLJ7jgke1ToASxp4F9nl5s+ODfdA2+lq5QOhYj1sgx7N6PBqR0jyiSg==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudfront": "1.107.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.107.0",
+        "@aws-cdk/aws-iam": "1.107.0",
+        "@aws-cdk/aws-s3": "1.107.0",
+        "@aws-cdk/core": "1.107.0",
+        "constructs": "^3.3.69"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudfront": "1.107.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.107.0",
+        "@aws-cdk/aws-iam": "1.107.0",
+        "@aws-cdk/aws-s3": "1.107.0",
         "@aws-cdk/core": "1.107.0",
         "constructs": "^3.3.69"
       }
@@ -365,7 +390,10 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.107.0.tgz",
       "integrity": "sha512-HFNmW12ow1FzBVdSmA76niV3lxOaowLPoS1LGRcRHTmMECZy6IpLPpY6oLK6UTvJnFWkVWtpyEnN+u6noz0w2A==",
       "bundleDependencies": [
-        "minimatch"
+        "minimatch",
+        "balanced-match",
+        "brace-expansion",
+        "concat-map"
       ],
       "peer": true,
       "dependencies": {
@@ -810,7 +838,9 @@
       "integrity": "sha512-z1WdnHrHGR6VF7p7Xv6MAwlr4sCGsFGGRJmk4WmvcFosOclLFKfSsxFE2w5RMmuyxLxdJmarSYF3AKOwm9mHng==",
       "bundleDependencies": [
         "jsonschema",
-        "semver"
+        "semver",
+        "lru-cache",
+        "yallist"
       ],
       "peer": true,
       "dependencies": {
@@ -871,7 +901,14 @@
         "fs-extra",
         "minimatch",
         "@balena/dockerignore",
-        "ignore"
+        "ignore",
+        "at-least-node",
+        "balanced-match",
+        "brace-expansion",
+        "concat-map",
+        "graceful-fs",
+        "jsonfile",
+        "universalify"
       ],
       "dependencies": {
         "@aws-cdk/cloud-assembly-schema": "1.107.0",
@@ -1016,7 +1053,9 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.107.0.tgz",
       "integrity": "sha512-nNfdagY9MVrvvDGPjmdCpBaLGZeMxGAGOOUxFpWbkE7PoDRWcESVf0s2BERsIRLglPEab4eJOQ8PNIBTThSkPQ==",
       "bundleDependencies": [
-        "semver"
+        "semver",
+        "lru-cache",
+        "yallist"
       ],
       "peer": true,
       "dependencies": {
@@ -4289,7 +4328,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -4489,6 +4529,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5429,7 +5470,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -11842,6 +11884,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17504,7 +17547,6 @@
       "version": "1.107.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.107.0.tgz",
       "integrity": "sha512-pMeCF4CUOT0Zor7gbZF5NT54Fn50b+bTSXYTRzM9v8nXlIFpo3HJAsIpVJRGNnDdLwwEXXmRzgx7dIE4UVzouw==",
-      "peer": true,
       "requires": {}
     },
     "@aws-cdk/aws-cloudformation": {
@@ -17518,6 +17560,12 @@
       "version": "1.107.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.107.0.tgz",
       "integrity": "sha512-92TRtZN46sQt4G8vTx7dPcUaUlLg0bLdnXSFErc2Rt0SybGPFMebu//woW79bGqYbU6Mpy0kerT3Ghk2tyizdA==",
+      "requires": {}
+    },
+    "@aws-cdk/aws-cloudfront-origins": {
+      "version": "1.107.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront-origins/-/aws-cloudfront-origins-1.107.0.tgz",
+      "integrity": "sha512-NLqFPPdc35HRXJV+3sybx3UpAhVNpUUJLJ7jgke1ToASxp4F9nl5s+ODfdA2+lq5QOhYj1sgx7N6PBqR0jyiSg==",
       "requires": {}
     },
     "@aws-cdk/aws-cloudwatch": {
@@ -20515,7 +20563,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -20680,6 +20729,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -21477,7 +21527,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "configstore": {
       "version": "5.0.1",
@@ -26610,6 +26661,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2": "1.107",
     "@aws-cdk/aws-apigatewayv2-integrations": "1.107",
+    "@aws-cdk/aws-certificatemanager": "1.107",
     "@aws-cdk/aws-cloudfront": "1.107.0",
+    "@aws-cdk/aws-cloudfront-origins": "1.107",
     "@aws-cdk/aws-cloudwatch": "1.107.0",
     "@aws-cdk/aws-events": "1.107.0",
     "@aws-cdk/aws-iam": "1.107.0",


### PR DESCRIPTION
Recently there was a new concept added to CloudFront: cache policies.

These are supposed to replace how we configure what is cached and what isn't.

This PR upgrades to using cache policies. Per https://github.com/getlift/lift/discussions/5#discussioncomment-712809 recommendation, this allows to use Brotli compression for faster loading times.

On the implementation side: this allows for a simpler configuration, mostly because we switch to the new `Distribution` class instead of the older `CloudFrontWebDistribution` class. See https://stackoverflow.com/a/65933937/245552 for more details.