### PR TITLE
Add a command and documentation to eject from Lift

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Deploy webhooks to receive notification from 3rd party applications.
 
 Got ideas for new constructs? [Open and upvote drafts](https://github.com/getlift/lift/discussions/categories/components).
 
+## Ejecting
+
+You can eject from Lift at any time: Lift is based on CloudFormation. That allows anyone to kickstart a project with Lift, and fallback to CloudFormation if you ever grow out of it.
+
+To eject:
+
+- export the CloudFormation template via `serverless lift eject`
+- copy the parts you want to turn into CloudFormation and paste them in the [`resources` section of serverless.yml](https://www.serverless.com/framework/docs/providers/aws/guide/resources/)
+- don't forget to remove from `serverless.yml` the Lift constructs you have turned into CloudFormation
+
 ---
 
 ## Lift is built and maintained with love ❤️ by

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "chalk": "^4.1.0",
         "change-case": "^4.1.1",
         "cidr-split": "^0.1.2",
-        "js-yaml": "^3.14.0",
+        "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
         "mime-types": "^2.1.30",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chalk": "^4.1.0",
     "change-case": "^4.1.1",
     "cidr-split": "^0.1.2",
-    "js-yaml": "^3.14.0",
+    "js-yaml": "^3.14.1",
     "lodash": "^4.17.21",
     "log-symbols": "^4.0.0",
     "mime-types": "^2.1.30",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -40,7 +40,7 @@ class LiftPlugin {
 
         this.serverless = serverless;
 
-        this.commands["lift"] = {
+        this.commands.lift = {
             commands: {
                 eject: {
                     lifecycleEvents: ["eject"],

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import { JSONSchema6 } from "json-schema";
 import { AwsIamPolicyStatements } from "@serverless/typescript";
 import * as path from "path";
 import { readFileSync } from "fs";
+import { dump } from "js-yaml";
 import type {
     CloudformationTemplate,
     CommandsDefinition,
@@ -210,8 +211,8 @@ class LiftPlugin {
         const compiledTemplateFileName = legacyProvider.naming.getCompiledTemplateFileName();
         const compiledTemplateFilePath = path.join(this.serverless.serviceDir, ".serverless", compiledTemplateFileName);
         const cfTemplate = readFileSync(compiledTemplateFilePath);
-        const formattedJson = JSON.stringify(JSON.parse(cfTemplate.toString()), undefined, 2);
-        console.log(formattedJson);
+        const formattedYaml = dump(JSON.parse(cfTemplate.toString()));
+        console.log(formattedYaml);
         log("You can also find that CloudFormation template in the following file:");
         log(compiledTemplateFilePath);
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,8 @@ import { has, merge } from "lodash";
 import chalk from "chalk";
 import { JSONSchema6 } from "json-schema";
 import { AwsIamPolicyStatements } from "@serverless/typescript";
+import * as path from "path";
+import { readFileSync } from "fs";
 import type {
     CloudformationTemplate,
     CommandsDefinition,
@@ -13,6 +15,7 @@ import type {
 import Construct from "./classes/Construct";
 import AwsProvider from "./classes/AwsProvider";
 import { constructs } from "./components";
+import { log } from "./utils/logger";
 
 type MinimallyValidConstructConfig = { type: string; [k: string]: unknown };
 
@@ -36,12 +39,21 @@ class LiftPlugin {
 
         this.serverless = serverless;
 
+        this.commands["lift"] = {
+            commands: {
+                eject: {
+                    lifecycleEvents: ["eject"],
+                },
+            },
+        };
+
         this.hooks = {
             initialize: this.appendPermissions.bind(this),
             "before:aws:info:displayStackOutputs": this.info.bind(this),
             "after:package:compileEvents": this.appendCloudformationResources.bind(this),
             "after:deploy:deploy": this.postDeploy.bind(this),
             "before:remove:remove": this.preRemove.bind(this),
+            "lift:eject:eject": this.eject.bind(this),
         };
 
         // TODO variables should be resolved just before deploying each provider
@@ -189,6 +201,19 @@ class LiftPlugin {
         }
         this.serverless.service.provider.iamRoleStatements = this.serverless.service.provider.iamRoleStatements ?? [];
         this.serverless.service.provider.iamRoleStatements.push(...statements);
+    }
+
+    private async eject() {
+        log("Ejecting from Lift to CloudFormation");
+        await this.serverless.pluginManager.spawn("package");
+        const legacyProvider = this.serverless.getProvider("aws");
+        const compiledTemplateFileName = legacyProvider.naming.getCompiledTemplateFileName();
+        const compiledTemplateFilePath = path.join(this.serverless.serviceDir, ".serverless", compiledTemplateFileName);
+        const cfTemplate = readFileSync(compiledTemplateFilePath);
+        const formattedJson = JSON.stringify(JSON.parse(cfTemplate.toString()), undefined, 2);
+        console.log(formattedJson);
+        log("You can also find that CloudFormation template in the following file:");
+        log(compiledTemplateFilePath);
     }
 }
 

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -24,6 +24,7 @@ export type Provider = {
     naming: {
         getStackName: () => string;
         getLambdaLogicalId: (functionName: string) => string;
+        getCompiledTemplateFileName: () => string;
     };
     getRegion: () => string;
     /**
@@ -35,8 +36,10 @@ export type Provider = {
 export type Serverless = {
     // To use only in tests
     stack: Stack;
+    serviceDir: string;
     pluginManager: {
         addPlugin: (plugin: unknown) => void;
+        spawn: (command: string) => Promise<void>;
     };
     configSchemaHandler: {
         defineTopLevelProperty: (pluginName: string, schema: JSONSchema) => void;


### PR DESCRIPTION
This PR adds a new `serverless lift eject` command. It also adds the related documentation.

This allows users to eject from Lift (to CloudFormation) easily.

Preview of the command:

<img width="830" alt="Screen 20210607 KWNKp2nc@2x" src="https://user-images.githubusercontent.com/720328/121053304-8048d280-c7bb-11eb-8c59-ba8f8527c8a4.png">
<img width="917" alt="Screen 20210607 RW7cuLnD@2x" src="https://user-images.githubusercontent.com/720328/121053318-82ab2c80-c7bb-11eb-8aa3-166f6545387e.png">

