### PR TITLE
Improve schema validation logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,5 @@ jobs:
                     path: ~/.npm
                     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
             -   run: npm ci
+            -   run: npm run lint
             -   run: npm test

--- a/src/constructs/Queue.ts
+++ b/src/constructs/Queue.ts
@@ -30,7 +30,7 @@ export const QUEUE_DEFINITION = {
         },
     },
     additionalProperties: false,
-    required: ["type", "worker"],
+    required: ["worker"],
 } as const;
 type Configuration = FromSchema<typeof QUEUE_DEFINITION>;
 

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -50,7 +50,7 @@ export const STATIC_WEBSITE_DEFINITION = {
         },
     },
     additionalProperties: false,
-    required: ["type", "path"],
+    required: ["path"],
 } as const;
 
 type Configuration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;

--- a/src/constructs/Storage.ts
+++ b/src/constructs/Storage.ts
@@ -15,7 +15,6 @@ export const STORAGE_DEFINITION = {
         },
     },
     additionalProperties: false,
-    required: ["type"],
 } as const;
 const STORAGE_DEFAULTS: Required<FromSchema<typeof STORAGE_DEFINITION>> = {
     type: "storage",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,7 +5,7 @@ export function log(message: string): void {
 }
 
 export function debug(message: string): void {
-    if (process.env.SLS_DEBUG) {
+    if (process.env.SLS_DEBUG !== undefined) {
         console.log(chalk.gray("Lift: " + message));
     }
 }

--- a/test/fixtures/staticWebsites/public/scripts.js
+++ b/test/fixtures/staticWebsites/public/scripts.js
@@ -1,1 +1,3 @@
 function main() {}
+
+main();

--- a/test/utils/runServerless.ts
+++ b/test/utils/runServerless.ts
@@ -2,8 +2,8 @@ import path from "path";
 import { Names } from "@aws-cdk/core";
 import type originalRunServerless from "@serverless/test/run-serverless";
 import setupRunServerlessFixturesEngine from "@serverless/test/setup-run-serverless-fixtures-engine";
-import { Serverless } from "../../src/types/serverless";
 import type { AWS } from "@serverless/typescript";
+import { Serverless } from "../../src/types/serverless";
 
 type ComputeLogicalId = (...address: string[]) => string;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "experimentalDecorators": true,
     "isolatedModules": true,
     "skipLibCheck": true,
+    "sourceMap": true,
   },
   "include": [
     "src",


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->

Current code base contains multiple eslint validation errors

```
/Users/Frederic/Sites/lift/src/plugin.ts
    4:29   error    'json-schema' should be listed in the project's dependencies. Run 'npm i -S json-schema' to add it  import/no-extraneous-dependencies
   77:39   error    Unsafe member access [configuration.type] on an `any` value                                         @typescript-eslint/no-unsafe-member-access
   77:54   warning  Unexpected any. Specify a different type                                                            @typescript-eslint/no-explicit-any
   92:19   error    Unsafe assignment of an `any` value                                                                 @typescript-eslint/no-unsafe-assignment
   92:26   error    Unsafe member access [configuration.type] on an `any` value                                         @typescript-eslint/no-unsafe-member-access
   92:41   warning  Unexpected any. Specify a different type                                                            @typescript-eslint/no-explicit-any
   94:35   error    Unsafe construction of an any type value                                                            @typescript-eslint/no-unsafe-call
  169:100  warning  Unexpected any. Specify a different type                                                            @typescript-eslint/no-explicit-any

/Users/Frederic/Sites/lift/src/utils/logger.ts
  8:9  error  Unexpected nullable string value in conditional. Please handle the nullish/empty cases explicitly  @typescript-eslint/strict-boolean-expressions

/Users/Frederic/Sites/lift/test/fixtures/staticWebsites/public/scripts.js
  1:10  error  'main' is defined but never used  no-unused-vars

/Users/Frederic/Sites/lift/test/utils/runServerless.ts
  6:1  error  `@serverless/typescript` import should occur before import of `../../src/types/serverless`  import/order
  ```
    
This PR aims at :
- including `npm run lint` check in CI at test stage
- fix current issue on code base
- implement a new schema validation logic doing so
  
  