### PR TITLE
Queue: add CLI commands to manage SQS dead letter queues

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -156,7 +156,7 @@ Use this command to investigate why these messages failed to be processed.
 
 Note: this command will only fetch the first messages available (it will not dump thousands of messages into the terminal).
 
-![](https://user-images.githubusercontent.com/720328/121541663-cbefbc00-ca07-11eb-854b-cb7cd21da49d.mp4)
+https://user-images.githubusercontent.com/720328/121541663-cbefbc00-ca07-11eb-854b-cb7cd21da49d.mp4
 
 - `serverless <construct-name>:failed:purge`
 
@@ -170,7 +170,7 @@ This command retries all failed messages of the dead letter queue by moving them
 
 Use this command if you have failed messages and you want to retry them again.
 
-![](https://user-images.githubusercontent.com/720328/121541886-f5104c80-ca07-11eb-861c-3356c500ba3d.mp4)
+https://user-images.githubusercontent.com/720328/121541886-f5104c80-ca07-11eb-861c-3356c500ba3d.mp4
 
 ## Configuration reference
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -156,8 +156,6 @@ Use this command to investigate why these messages failed to be processed.
 
 Note: this command will only fetch the first messages available (it will not dump thousands of messages into the terminal).
 
-https://user-images.githubusercontent.com/720328/121541663-cbefbc00-ca07-11eb-854b-cb7cd21da49d.mp4
-
 - `serverless <construct-name>:failed:purge`
 
 This command clears all messages from the dead letter queue.
@@ -169,8 +167,6 @@ Use this command if you have failed messages and you don't want to retry them.
 This command retries all failed messages of the dead letter queue by moving them to the main queue.
 
 Use this command if you have failed messages and you want to retry them again.
-
-https://user-images.githubusercontent.com/720328/121541886-f5104c80-ca07-11eb-861c-3356c500ba3d.mp4
 
 ## Configuration reference
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -34,7 +34,7 @@ The `queue` construct deploys the following resources:
 
 To learn more about the architecture of this construct, [read this article](https://medium.com/serverless-transformation/serverless-queues-and-workers-designing-lift-d870afdba867).
 
-![](img/queue.png)
+<img src="img/queue.png" width="500"/>
 
 ## Variables
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -188,7 +188,7 @@ The only required setting is the `handler`: this should point to the code that h
 ```js
 exports.handler = async function (event, context) {
     event.Records.forEach(record => {
-        // `record` contains the job that was pushed to SQS
+        // `record` contains the message that was pushed to SQS
     });
 }
 ```
@@ -216,7 +216,7 @@ constructs:
         alarm: alerting@mycompany.com
 ```
 
-It is possible to configure email alerts in case jobs end up in the dead letter queue.
+It is possible to configure email alerts in case messages end up in the dead letter queue.
 
 After the first deployment, an email will be sent to the email address to confirm the subscription.
 
@@ -231,19 +231,19 @@ constructs:
 
 *Default: 3 retries.*
 
-SQS retries messages when the Lambda processing it throws an error. The `maxRetries` option configures how many times each job will be retried when failing.
+SQS retries messages when the Lambda processing it throws an error. The `maxRetries` option configures how many times each message will be retried in case of failure.
 
 Sidenote: errors should not be captured in the code of the `worker` function, else the retry mechanism will not be triggered.
 
-If the job still fails after reaching the max retry count, it will be moved to the dead letter queue for storage.
+If the message still fails after reaching the max retry count, it will be moved to the dead letter queue for storage.
 
 ### Retry delay
 
-When Lambda fails processing a SQS job (i.e. the code throws an error), the job will be retried after a delay. That delay is also called "**Visibility Timeout"** in SQS.
+When Lambda fails processing an SQS message (i.e. the code throws an error), the message will be retried after a delay. That delay is also called SQS "_Visibility Timeout_".
 
-By default, Lift configures the retry delay to 6 times the worker functions timeout, [per AWS' recommendation](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig). Since Serverless deploy functions with a timeout of 6 seconds by default, that means that jobs will be retried every 36 seconds.
+By default, Lift configures the retry delay to 6 times the worker functions timeout, [per AWS' recommendation](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig). Since Serverless deploy functions with a timeout of 6 seconds by default, that means that messages will be retried **every 36 seconds**.
 
-When the function's timeout is changed, the retry delay is configured accordingly:
+When the function's timeout is changed, the retry delay is automatically changed accordingly:
 
 ```yaml
 constructs:
@@ -267,11 +267,11 @@ constructs:
 
 *Default: 1*
 
-When the SQS queue contains more than 1 job to process, it can invoke Lambda with a batch of multiple messages at once.
+When the SQS queue contains more than 1 message to process, it can invoke Lambda with a batch of multiple messages at once.
 
-By default, Lambda will be invoked 1 messages at a time. The reason is to simplify error handling: in a batch, any failed message will fail the whole batch.
+By default, Lift configures Lambda to be invoked with 1 messages at a time. The reason is to simplify error handling: in a batch, any failed message will fail the whole batch.
 
-It is possible to change the batch size between 1 and 10.
+It is possible to set the batch size between 1 and 10.
 
 ### More options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/sinon": "^10.0.1",
         "@typescript-eslint/eslint-plugin": "^4.21.0",
         "@typescript-eslint/parser": "^4.21.0",
-        "aws-sdk-mock": "^5.1.0",
         "chai": "^4.2.0",
         "esbuild-node-tsc": "^1.4.0",
         "eslint": "^7.23.0",
@@ -4143,17 +4142,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-sdk-mock": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz",
-      "integrity": "sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==",
-      "dev": true,
-      "dependencies": {
-        "aws-sdk": "^2.637.0",
-        "sinon": "^9.0.1",
-        "traverse": "^0.6.6"
       }
     },
     "node_modules/aws-sign2": {
@@ -20412,17 +20400,6 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
-      }
-    },
-    "aws-sdk-mock": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-5.1.0.tgz",
-      "integrity": "sha512-Wa5eCSo8HX0Snqb7FdBylaXMmfrAWoWZ+d7MFhiYsgHPvNvMEGjV945FF2qqE1U0Tolr1ALzik1fcwgaOhqUWQ==",
-      "dev": true,
-      "requires": {
-        "aws-sdk": "^2.637.0",
-        "sinon": "^9.0.1",
-        "traverse": "^0.6.6"
       }
     },
     "aws-sign2": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/sinon": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
-    "aws-sdk-mock": "^5.1.0",
     "chai": "^4.2.0",
     "esbuild-node-tsc": "^1.4.0",
     "eslint": "^7.23.0",

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -1,6 +1,7 @@
 import { CfnOutput, Stack } from "@aws-cdk/core";
 import { getStackOutput } from "../CloudFormation";
 import { Provider as LegacyAwsProvider, Serverless } from "../types/serverless";
+import { awsRequest } from "./aws";
 
 export default class AwsProvider {
     public readonly region: string;
@@ -39,7 +40,7 @@ export default class AwsProvider {
     /**
      * Send a request to the AWS API.
      */
-    async request<Input, Output>(service: string, method: string, params: Input): Promise<Output> {
-        return await this.legacyProvider.request<Input, Output>(service, method, params);
+    request<Input, Output>(service: string, method: string, params: Input): Promise<Output> {
+        return awsRequest<Input, Output>(service, method, params, this.legacyProvider);
     }
 }

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -41,6 +41,6 @@ export default class AwsProvider {
      * Send a request to the AWS API.
      */
     request<Input, Output>(service: string, method: string, params: Input): Promise<Output> {
-        return awsRequest<Input, Output>(service, method, params, this.legacyProvider);
+        return awsRequest<Input, Output>(params, service, method, this.legacyProvider);
     }
 }

--- a/src/classes/aws.ts
+++ b/src/classes/aws.ts
@@ -1,0 +1,11 @@
+import { Provider as LegacyAwsProvider } from "../types/serverless";
+
+// This is defined as a separate function to allow mocking in tests
+export async function awsRequest<Input, Output>(
+    service: string,
+    method: string,
+    params: Input,
+    provider: LegacyAwsProvider
+): Promise<Output> {
+    return await provider.request<Input, Output>(service, method, params);
+}

--- a/src/classes/aws.ts
+++ b/src/classes/aws.ts
@@ -2,9 +2,9 @@ import { Provider as LegacyAwsProvider } from "../types/serverless";
 
 // This is defined as a separate function to allow mocking in tests
 export async function awsRequest<Input, Output>(
+    params: Input,
     service: string,
     method: string,
-    params: Input,
     provider: LegacyAwsProvider
 ): Promise<Output> {
     return await provider.request<Input, Output>(service, method, params);

--- a/src/constructs/Queue.ts
+++ b/src/constructs/Queue.ts
@@ -131,7 +131,7 @@ export class Queue extends CdkConstruct implements Construct {
     commands(): Record<string, () => void | Promise<void>> {
         return {
             failed: () => this.listDlq(),
-            "failed:clear": () => this.clearDlq(),
+            "failed:purge": () => this.purgeDlq(),
             "failed:retry": () => this.retryDlq(),
         };
     }
@@ -222,11 +222,11 @@ export class Queue extends CdkConstruct implements Construct {
             console.log();
         }
         const retryCommand = chalk.bold(`serverless ${this.id}:failed:retry`);
-        const clearCommand = chalk.bold(`serverless ${this.id}:failed:clear`);
-        console.log(`Run ${retryCommand} to retry all messages, or ${clearCommand} to delete those messages forever.`);
+        const purgeCommand = chalk.bold(`serverless ${this.id}:failed:purge`);
+        console.log(`Run ${retryCommand} to retry all messages, or ${purgeCommand} to delete those messages forever.`);
     }
 
-    async clearDlq(): Promise<void> {
+    async purgeDlq(): Promise<void> {
         const dlqUrl = await this.getDlqUrl();
         if (dlqUrl === undefined) {
             console.log(
@@ -237,7 +237,7 @@ export class Queue extends CdkConstruct implements Construct {
 
             return;
         }
-        const progress = ora("Clearing the dead letter queue of failed messages").start();
+        const progress = ora("Purging the dead letter queue of failed messages").start();
         await this.provider.request<PurgeQueueRequest, void>("SQS", "purgeQueue", {
             QueueUrl: dlqUrl,
         });
@@ -247,7 +247,7 @@ export class Queue extends CdkConstruct implements Construct {
          * are less chances that deleted messages show up again.
          */
         await sleep(500);
-        progress.succeed("The dead letter queue has been cleared, failed messages are gone 🙈");
+        progress.succeed("The dead letter queue has been purged, failed messages are gone 🙈");
     }
 
     async retryDlq(): Promise<void> {

--- a/src/constructs/queue/sqs.ts
+++ b/src/constructs/queue/sqs.ts
@@ -1,0 +1,122 @@
+import {
+    DeleteMessageBatchRequest,
+    DeleteMessageBatchResult,
+    Message,
+    ReceiveMessageRequest,
+    ReceiveMessageResult,
+    SendMessageBatchRequest,
+    SendMessageBatchResult,
+} from "aws-sdk/clients/sqs";
+import AwsProvider from "../../classes/AwsProvider";
+import { log } from "../../utils/logger";
+import { sleep } from "../../utils/sleep";
+
+type ProgressCallback = (numberOfMessagesFound: number) => void;
+
+export async function pollMessages(
+    aws: AwsProvider,
+    queueUrl: string,
+    progressCallback?: ProgressCallback
+): Promise<Message[]> {
+    const messages: Message[] = [];
+    const promises = [];
+    // Poll in parallel to hit multiple SQS servers at once
+    // See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html
+    // (a single request might not return all messages)
+    for (let i = 0; i < 5; i++) {
+        promises.push(
+            pollMoreMessages(aws, queueUrl, messages).then(() => {
+                if (progressCallback && messages.length > 0) {
+                    progressCallback(messages.length);
+                }
+            })
+        );
+        await sleep(200);
+    }
+    await Promise.all(promises);
+
+    return messages;
+}
+
+async function pollMoreMessages(aws: AwsProvider, queueUrl: string, messages: Message[]): Promise<void> {
+    const messagesResponse = await aws.request<ReceiveMessageRequest, ReceiveMessageResult>("SQS", "receiveMessage", {
+        QueueUrl: queueUrl,
+        // 10 is the maximum
+        MaxNumberOfMessages: 10,
+        WaitTimeSeconds: 5,
+        // Only hide messages for 1 second
+        VisibilityTimeout: 1,
+    });
+    for (const newMessage of messagesResponse.Messages ?? []) {
+        const alreadyInTheList = messages.some((message) => {
+            return message.MessageId === newMessage.MessageId;
+        });
+        if (!alreadyInTheList) {
+            messages.push(newMessage);
+        }
+    }
+}
+
+export async function retryMessages(
+    aws: AwsProvider,
+    queueUrl: string,
+    dlqUrl: string,
+    messages: Message[]
+): Promise<{
+    numberOfMessagesRetried: number;
+    numberOfMessagesNotRetried: number;
+    numberOfMessagesRetriedButNotDeleted: number;
+}> {
+    if (messages.length === 0) {
+        return {
+            numberOfMessagesRetried: 0,
+            numberOfMessagesNotRetried: 0,
+            numberOfMessagesRetriedButNotDeleted: 0,
+        };
+    }
+
+    const sendResult = await aws.request<SendMessageBatchRequest, SendMessageBatchResult>("SQS", "sendMessageBatch", {
+        QueueUrl: queueUrl,
+        Entries: messages.map((message) => {
+            if (message.MessageId === undefined) {
+                throw new Error(`Found a message with no ID`);
+            }
+
+            return {
+                Id: message.MessageId,
+                MessageAttributes: message.MessageAttributes,
+                MessageBody: message.Body as string,
+            };
+        }),
+    });
+    const messagesToDelete = messages.filter((message) => {
+        const isMessageInFailedList = sendResult.Failed.some((failedMessage) => message.MessageId === failedMessage.Id);
+
+        return !isMessageInFailedList;
+    });
+
+    const deletionResult = await aws.request<DeleteMessageBatchRequest, DeleteMessageBatchResult>(
+        "SQS",
+        "deleteMessageBatch",
+        {
+            QueueUrl: dlqUrl,
+            Entries: messagesToDelete.map((message) => {
+                return {
+                    Id: message.MessageId as string,
+                    ReceiptHandle: message.ReceiptHandle as string,
+                };
+            }),
+        }
+    );
+    if (deletionResult.Failed.length > 0) {
+        log(
+            `${deletionResult.Failed.length} failed messages were not successfully deleted from the dead letter queue. These messages will be retried in the main queue, but they will also still be present in the dead letter queue.`
+        );
+    }
+
+    return {
+        numberOfMessagesRetried: deletionResult.Successful.length,
+        numberOfMessagesNotRetried: sendResult.Failed.length,
+        numberOfMessagesRetriedButNotDeleted: deletionResult.Failed.length,
+    };
+}

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/unit/queues.test.ts
+++ b/test/unit/queues.test.ts
@@ -263,7 +263,7 @@ describe("queues", () => {
         });
     });
 
-    it("should clear messages from the DLQ", async () => {
+    it("should purge messages from the DLQ", async () => {
         const awsMock = mockAws();
         sinon.stub(CloudFormationHelpers, "getStackOutput").returns(Promise.resolve("queue-url"));
         awsMock.mockService("SQS", "purgeQueue");
@@ -272,7 +272,7 @@ describe("queues", () => {
         await runServerless({
             fixture: "queues",
             configExt: pluginConfigExt,
-            cliArgs: ["emails:failed:clear"],
+            cliArgs: ["emails:failed:purge"],
         });
 
         // TODO simplify `.args[2]`

--- a/test/unit/staticWebsites.test.ts
+++ b/test/unit/staticWebsites.test.ts
@@ -1,16 +1,14 @@
-import AWSMock from "aws-sdk-mock";
 import * as sinon from "sinon";
-import { ListObjectsV2Output, ListObjectsV2Request } from "aws-sdk/clients/s3";
 import * as fs from "fs";
 import * as path from "path";
 import { baseConfig, pluginConfigExt, runServerless } from "../utils/runServerless";
 import * as CloudFormationHelpers from "../../src/CloudFormation";
 import { computeS3ETag } from "../../src/utils/s3-sync";
+import { mockAws } from "../utils/mockAws";
 
 describe("static websites", () => {
     afterEach(() => {
         sinon.restore();
-        AWSMock.restore();
     });
 
     it("should create all required resources", async () => {
@@ -309,7 +307,8 @@ describe("static websites", () => {
     });
 
     it("should synchronize files to S3", async () => {
-        sinon.stub(CloudFormationHelpers, "getStackOutput").returns(Promise.resolve("bucket-name"));
+        const awsMock = mockAws();
+        sinon.stub(CloudFormationHelpers, "getStackOutput").resolves("bucket-name");
         /*
          * This scenario simulates the following:
          * - index.html is up to date, it should be ignored
@@ -317,22 +316,22 @@ describe("static websites", () => {
          * - scripts.js is new, it should be created in S3
          * - image.jpg doesn't exist on disk, it should be removed from S3
          */
-        mockBucketContent([
-            {
-                Key: "index.html",
-                ETag: computeS3ETag(
-                    fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/index.html"))
-                ),
-            },
-            { Key: "styles.css" },
-            { Key: "image.jpg" },
-        ]);
-        const putObjectSpy = sinon.stub().returns(Promise.resolve());
-        AWSMock.mock("S3", "putObject", putObjectSpy);
-        const deleteObjectsSpy = sinon.stub().returns(Promise.resolve());
-        AWSMock.mock("S3", "deleteObjects", deleteObjectsSpy);
-        const cloudfrontInvalidationSpy = sinon.stub().returns(Promise.resolve());
-        AWSMock.mock("CloudFront", "createInvalidation", cloudfrontInvalidationSpy);
+        awsMock.mockService("S3", "listObjectsV2").resolves({
+            IsTruncated: false,
+            Contents: [
+                {
+                    Key: "index.html",
+                    ETag: computeS3ETag(
+                        fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/index.html"))
+                    ),
+                },
+                { Key: "styles.css" },
+                { Key: "image.jpg" },
+            ],
+        });
+        const putObjectSpy = awsMock.mockService("S3", "putObject");
+        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects");
+        const cloudfrontInvalidationSpy = awsMock.mockService("CloudFront", "createInvalidation");
 
         await runServerless({
             fixture: "staticWebsites",
@@ -370,16 +369,3 @@ describe("static websites", () => {
         sinon.assert.calledOnce(cloudfrontInvalidationSpy);
     });
 });
-
-function mockBucketContent(objects: Array<{ Key: string; ETag?: string }>) {
-    AWSMock.mock(
-        "S3",
-        "listObjectsV2",
-        (params: ListObjectsV2Request, callback: (a: null, b: ListObjectsV2Output) => void) => {
-            callback(null, {
-                IsTruncated: false,
-                Contents: objects,
-            });
-        }
-    );
-}

--- a/test/utils/mockAws.ts
+++ b/test/utils/mockAws.ts
@@ -3,11 +3,14 @@ import { SinonStub } from "sinon";
 import * as AWS from "../../src/classes/aws";
 import { Provider as LegacyAwsProvider } from "../../src/types/serverless";
 
+/**
+ * Helper to mock the AWS SDK
+ */
 export function mockAws(): AwsMock {
     const awsMock = sinon.stub(AWS, "awsRequest") as AwsMock;
 
     awsMock.mockService = (service: string, method: string) => {
-        return awsMock.withArgs(service, method, sinon.match.any, sinon.match.any);
+        return awsMock.withArgs(sinon.match.any, service, method, sinon.match.any).resolves();
     };
 
     return awsMock;

--- a/test/utils/mockAws.ts
+++ b/test/utils/mockAws.ts
@@ -1,0 +1,25 @@
+import * as sinon from "sinon";
+import { SinonStub } from "sinon";
+import * as AWS from "../../src/classes/aws";
+import { Provider as LegacyAwsProvider } from "../../src/types/serverless";
+
+export function mockAws(): AwsMock {
+    const awsMock = sinon.stub(AWS, "awsRequest") as AwsMock;
+
+    awsMock.mockService = (service: string, method: string) => {
+        return awsMock.withArgs(service, method, sinon.match.any, sinon.match.any);
+    };
+
+    return awsMock;
+}
+
+type AwsMock = SinonAwsMock & ExtendedAwsMock;
+
+type SinonAwsMock = SinonStub<
+    [service: string, method: string, params: unknown, provider: LegacyAwsProvider],
+    Promise<unknown>
+>;
+
+interface ExtendedAwsMock {
+    mockService(service: string, method: string): SinonAwsMock;
+}


### PR DESCRIPTION
This PR enhances the `queue` construct with new CLI commands.

```
serverless <queue-construct>:failed
serverless <queue-construct>:failed:purge
serverless <queue-construct>:failed:retry
```

Read below for gifs and examples.

TODO:

- [x] Documentation

## Example

Given this `serverless.yml` config:

```yaml
# ...

constructs:

    jobs:
        type: queue
        worker:
            handler: worker.handler
```

Users can now run:

```
serverless jobs:failed
```

This command will list messages from the dead letter queue. It will only attempt to fetch the first 30 messages (it wouldn't make sense to poll thousands of messages and dump them in the terminal).


https://user-images.githubusercontent.com/720328/121541663-cbefbc00-ca07-11eb-854b-cb7cd21da49d.mp4

```
serverless jobs:failed:purge
```

This command clears the dead letter queue.

```
serverless jobs:failed:retry
```

This command moves all messages from the dead letter queue to the main queue. This is done by:

- polling the DLQ; for each message found:
    - send the message to the main queue
    - delete the message from the DLQ

https://user-images.githubusercontent.com/720328/121541886-f5104c80-ca07-11eb-861c-3356c500ba3d.mp4
