### PR TITLE
Move CDK logic to AwsProvider and implement factory logic for Construct build

### DIFF
--- a/src/CloudFormation.ts
+++ b/src/CloudFormation.ts
@@ -1,7 +1,7 @@
 import { DescribeStacksInput, DescribeStacksOutput } from "aws-sdk/clients/cloudformation";
 import { CfnOutput, Stack } from "@aws-cdk/core";
 import { debug } from "./utils/logger";
-import AwsProvider from "./classes/AwsProvider";
+import { AwsProvider } from "./classes/AwsProvider";
 
 export async function getStackOutput(aws: AwsProvider, output: CfnOutput): Promise<string | undefined> {
     const outputId = Stack.of(output.stack).resolve(output.logicalId) as string;

--- a/src/classes/AwsConstruct.ts
+++ b/src/classes/AwsConstruct.ts
@@ -1,0 +1,25 @@
+import { Construct as CdkConstruct } from "@aws-cdk/core";
+import { ConstructInterface } from ".";
+import { AwsProvider } from "./AwsProvider";
+
+export abstract class AwsConstruct<T extends Record<string, unknown>>
+    extends CdkConstruct
+    implements ConstructInterface {
+    constructor(
+        protected readonly scope: CdkConstruct,
+        protected readonly id: string,
+        protected readonly configuration: T,
+        protected readonly provider: AwsProvider
+    ) {
+        super(scope, id);
+    }
+
+    abstract outputs(): Record<string, () => Promise<string | undefined>>;
+
+    abstract commands(): Record<string, () => void | Promise<void>>;
+
+    /**
+     * CloudFormation references
+     */
+    abstract references(): Record<string, Record<string, unknown>>;
+}

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -1,20 +1,38 @@
-import { CfnOutput, Stack } from "@aws-cdk/core";
+import { App, CfnOutput, Stack } from "@aws-cdk/core";
+import { get, merge } from "lodash";
 import { getStackOutput } from "../CloudFormation";
-import { Provider as LegacyAwsProvider, Serverless } from "../types/serverless";
+import { Constructs } from "../constructs";
+import { CloudformationTemplate, Provider as LegacyAwsProvider, Serverless } from "../types/serverless";
 import { awsRequest } from "./aws";
+import { AwsConstruct } from ".";
 
-export default class AwsProvider {
+export class AwsProvider {
+    private readonly app: App;
+    private readonly stack: Stack;
     public readonly region: string;
     public readonly stackName: string;
     private readonly legacyProvider: LegacyAwsProvider;
     public naming: { getStackName: () => string; getLambdaLogicalId: (functionName: string) => string };
 
-    constructor(private readonly serverless: Serverless, public readonly stack: Stack) {
+    constructor(private readonly serverless: Serverless) {
+        this.app = new App();
+        this.stack = new Stack(this.app);
+        serverless.stack = this.stack;
         this.stackName = serverless.getProvider("aws").naming.getStackName();
 
         this.legacyProvider = serverless.getProvider("aws");
         this.naming = this.legacyProvider.naming;
         this.region = serverless.getProvider("aws").getRegion();
+    }
+
+    create(type: string, id: string): AwsConstruct<Record<string, unknown>> {
+        const configuration = get(this.serverless.configurationInput.constructs, id, {});
+        for (const Construct of Object.values(Constructs)) {
+            if (Construct.type === type) {
+                return Construct.create(this.stack, id, configuration, this);
+            }
+        }
+        throw new Error(`Construct ${id} has unsupported construct type: ${type}`);
     }
 
     addFunction(functionName: string, functionConfig: unknown): void {
@@ -42,5 +60,11 @@ export default class AwsProvider {
      */
     request<Input, Output>(service: string, method: string, params: Input): Promise<Output> {
         return awsRequest<Input, Output>(params, service, method, this.legacyProvider);
+    }
+
+    appendCloudformationResources(): void {
+        merge(this.serverless.service, {
+            resources: this.app.synth().getStackByName(this.stack.stackName).template as CloudformationTemplate,
+        });
     }
 }

--- a/src/classes/Construct.ts
+++ b/src/classes/Construct.ts
@@ -1,6 +1,6 @@
 import { PolicyStatement } from "../CloudFormation";
 
-export default interface Construct {
+export interface ConstructInterface {
     outputs(): Record<string, () => Promise<string | undefined>>;
 
     commands(): Record<string, () => void | Promise<void>>;

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -1,0 +1,3 @@
+export { AwsConstruct } from "./AwsConstruct";
+export { AwsProvider } from "./AwsProvider";
+export type { ConstructInterface } from "./Construct";

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -23,8 +23,7 @@ import { S3Origin } from "@aws-cdk/aws-cloudfront-origins";
 import * as acm from "@aws-cdk/aws-certificatemanager";
 import { log } from "../utils/logger";
 import { s3Sync } from "../utils/s3-sync";
-import AwsProvider from "../classes/AwsProvider";
-import Construct from "../classes/Construct";
+import { AwsConstruct, AwsProvider } from "../classes";
 
 export const STATIC_WEBSITE_DEFINITION = {
     type: "object",
@@ -55,19 +54,35 @@ export const STATIC_WEBSITE_DEFINITION = {
 
 type Configuration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;
 
-export class StaticWebsite extends CdkConstruct implements Construct {
+const isValidStaticWebsiteConfiguration = (
+    configuration: Record<string, unknown>
+): configuration is FromSchema<typeof STATIC_WEBSITE_DEFINITION> => {
+    return true;
+};
+
+export class StaticWebsite extends AwsConstruct<Configuration> {
+    public static type = "static-website";
+    public static schema = STATIC_WEBSITE_DEFINITION;
+    public static create(
+        scope: CdkConstruct,
+        id: string,
+        configuration: Record<string, unknown>,
+        provider: AwsProvider
+    ): StaticWebsite {
+        if (!isValidStaticWebsiteConfiguration(configuration)) {
+            throw new Error("Wrong configuration");
+        }
+
+        return new StaticWebsite(scope, id, configuration, provider);
+    }
+
     private readonly bucketNameOutput: CfnOutput;
     private readonly domainOutput: CfnOutput;
     private readonly cnameOutput: CfnOutput;
     private readonly distributionIdOutput: CfnOutput;
 
-    constructor(
-        scope: CdkConstruct,
-        private readonly id: string,
-        readonly configuration: Configuration,
-        private readonly provider: AwsProvider
-    ) {
-        super(scope, id);
+    constructor(scope: CdkConstruct, id: string, configuration: Configuration, provider: AwsProvider) {
+        super(scope, id, configuration, provider);
 
         if (configuration.domain !== undefined && configuration.certificate === undefined) {
             throw new Error(

--- a/src/constructs/index.ts
+++ b/src/constructs/index.ts
@@ -1,23 +1,6 @@
-import { Storage, STORAGE_DEFINITION } from "./Storage";
-import { Queue, QUEUE_DEFINITION } from "./Queue";
-import { STATIC_WEBSITE_DEFINITION, StaticWebsite } from "./StaticWebsite";
-import { Webhook, WEBHOOK_DEFINITION } from "./Webhook";
+import { Storage } from "./Storage";
+import { Queue } from "./Queue";
+import { StaticWebsite } from "./StaticWebsite";
+import { Webhook } from "./Webhook";
 
-export const constructs = {
-    storage: {
-        class: Storage,
-        schema: STORAGE_DEFINITION,
-    },
-    queue: {
-        class: Queue,
-        schema: QUEUE_DEFINITION,
-    },
-    "static-website": {
-        class: StaticWebsite,
-        schema: STATIC_WEBSITE_DEFINITION,
-    },
-    webhook: {
-        class: Webhook,
-        schema: WEBHOOK_DEFINITION,
-    },
-};
+export const Constructs = { Storage, Queue, StaticWebsite, Webhook };

--- a/src/constructs/queue/sqs.ts
+++ b/src/constructs/queue/sqs.ts
@@ -7,7 +7,7 @@ import {
     SendMessageBatchRequest,
     SendMessageBatchResult,
 } from "aws-sdk/clients/sqs";
-import AwsProvider from "../../classes/AwsProvider";
+import { AwsProvider } from "../../classes/AwsProvider";
 import { log } from "../../utils/logger";
 import { sleep } from "../../utils/sleep";
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,37 +1,20 @@
-import { App, Stack } from "@aws-cdk/core";
 import { get, has, merge } from "lodash";
 import chalk from "chalk";
 import { AwsIamPolicyStatements } from "@serverless/typescript";
 import * as path from "path";
 import { readFileSync } from "fs";
 import { dump } from "js-yaml";
-import { FromSchema } from "json-schema-to-ts";
-import type {
-    CloudformationTemplate,
-    CommandsDefinition,
-    Hook,
-    Serverless,
-    VariableResolver,
-} from "./types/serverless";
-import Construct from "./classes/Construct";
-import AwsProvider from "./classes/AwsProvider";
-import { constructs } from "./constructs";
+import type { CommandsDefinition, Hook, Serverless, VariableResolver } from "./types/serverless";
+import { AwsProvider, ConstructInterface } from "./classes";
 import { log } from "./utils/logger";
+import { Constructs } from "./constructs";
 
+const CONSTRUCT_ID_PATTERN = "^[a-zA-Z0-9-_]+$";
 const CONSTRUCTS_DEFINITION = {
     type: "object",
     patternProperties: {
-        "^[a-zA-Z0-9-_]+$": {
+        [CONSTRUCT_ID_PATTERN]: {
             allOf: [
-                {
-                    // Replacing with a map on constructs values generates type (A | B | C)[] instead of A, B, C
-                    anyOf: [
-                        constructs.storage.schema,
-                        constructs["static-website"].schema,
-                        constructs.webhook.schema,
-                        constructs.queue.schema,
-                    ],
-                },
                 {
                     type: "object",
                     properties: {
@@ -39,30 +22,25 @@ const CONSTRUCTS_DEFINITION = {
                     },
                     required: ["type"],
                 },
-            ],
+            ] as Record<string, unknown>[],
         },
     },
     additionalProperties: false,
-} as const;
+};
 
 /**
  * Serverless plugin
  */
 class LiftPlugin {
-    private readonly constructs: Record<string, Construct> = {};
+    private readonly constructs: Record<string, ConstructInterface> = {};
     private readonly serverless: Serverless;
-    private readonly app: App;
-    // Only public to be used in tests
-    public readonly stack: Stack;
+    private readonly providers: AwsProvider[] = [];
+    private readonly schema = CONSTRUCTS_DEFINITION;
     public readonly hooks: Record<string, Hook>;
     public readonly commands: CommandsDefinition = {};
     public readonly configurationVariablesSources: Record<string, VariableResolver> = {};
 
     constructor(serverless: Serverless) {
-        this.app = new App();
-        this.stack = new Stack(this.app);
-        serverless.stack = this.stack;
-
         this.serverless = serverless;
 
         this.commands.lift = {
@@ -91,24 +69,41 @@ class LiftPlugin {
             },
         };
 
+        this.registerConstructs();
         this.registerConfigSchema();
+        this.registerProviders();
         this.loadConstructs();
         this.registerCommands();
     }
 
+    private registerConstructs() {
+        this.schema.patternProperties[CONSTRUCT_ID_PATTERN].allOf.push({
+            oneOf: Object.values(Constructs).map((Construct) => {
+                return this.defineConstructSchema(Construct.type, Construct.schema);
+            }),
+        });
+    }
+
+    private defineConstructSchema(
+        constructName: string,
+        configSchema: Record<string, unknown>
+    ): Record<string, unknown> {
+        return merge(configSchema, { properties: { type: { const: constructName } } });
+    }
+
     private registerConfigSchema() {
-        this.serverless.configSchemaHandler.defineTopLevelProperty("constructs", CONSTRUCTS_DEFINITION);
+        this.serverless.configSchemaHandler.defineTopLevelProperty("constructs", this.schema);
+    }
+
+    private registerProviders() {
+        this.providers.push(new AwsProvider(this.serverless));
     }
 
     private loadConstructs() {
-        const awsProvider = new AwsProvider(this.serverless, this.stack);
-        const constructsInputConfiguration = get(this.serverless.configurationInput, "constructs", {}) as FromSchema<
-            typeof CONSTRUCTS_DEFINITION
-        >;
-        for (const [id, configuration] of Object.entries(constructsInputConfiguration)) {
-            const constructConstructor = constructs[configuration.type].class;
-            // Typescript cannot infer configuration specific to a type, thus computing intersetion of all configurations to never
-            this.constructs[id] = new constructConstructor(awsProvider.stack, id, configuration as never, awsProvider);
+        const constructsInputConfiguration = get(this.serverless.configurationInput, "constructs", {});
+        for (const [id, { type }] of Object.entries(constructsInputConfiguration)) {
+            const provider = this.providers[0];
+            this.constructs[id] = provider.create(type, id);
         }
     }
 
@@ -179,9 +174,7 @@ class LiftPlugin {
     }
 
     private appendCloudformationResources() {
-        merge(this.serverless.service, {
-            resources: this.app.synth().getStackByName(this.stack.stackName).template as CloudformationTemplate,
-        });
+        this.providers[0].appendCloudformationResources();
     }
 
     private appendPermissions(): void {

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -1,4 +1,3 @@
-import type { JSONSchema } from "json-schema-to-ts";
 import type { AWS } from "@serverless/typescript";
 import type { Stack } from "@aws-cdk/core";
 
@@ -42,9 +41,9 @@ export type Serverless = {
         spawn: (command: string) => Promise<void>;
     };
     configSchemaHandler: {
-        defineTopLevelProperty: (pluginName: string, schema: JSONSchema) => void;
+        defineTopLevelProperty: (pluginName: string, schema: Record<string, unknown>) => void;
     };
-    configurationInput: AWS;
+    configurationInput: AWS & { constructs?: Record<string, { type: string }> };
     service: AWS;
     getProvider: (provider: "aws") => Provider;
 };

--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -14,7 +14,7 @@ import * as crypto from "crypto";
 import { lookup } from "mime-types";
 import { chunk } from "lodash";
 import chalk from "chalk";
-import AwsProvider from "../classes/AwsProvider";
+import { AwsProvider } from "../classes/AwsProvider";
 
 const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);


### PR DESCRIPTION
This PR segregates code responsabilities across Lift code base. It introduces a few core concepts.

A construct is a class with:
- **Static members**, like `schema` and `type`, which are valid for all instances. Those static member can be seen as an API to the construct "catalog". When browsing existing constructs, you don't need to actually build one with the `new...` keyword, only need to access its static members.
- **Non-static members**, enforced via the `ConstructInterface`, exposing API to interact with a specific instance of this construct (i.e. `commands`, `outputs`, `references`)

Plugin entry point is responsible for:
- collecting all available schemas from the construct catalog (accessing static member of each Construct class)
- creating AwsProvider instance
- keeping an index of created Construct instances but delegating actual creation of those construct to the appropriate AwsProvider

A concise exemple of this pattern:

```ts

export interface ServerlessConstruct {
    commands(): unknown;
    //...
}

abstract class AwsConstruct extends CdkConstruct implements ServerlessConstruct {
    constructor(public readonly schema: JSONSchema, scope: CdkConstruct, id: string) {
        super(scope, id);
    }
    abstract commands(): unknown;
}

const StorageSchema = {
    type: "object",
    properties: { archive: { type: "string" } },
    required: ["archive"],
    additionalProperties: false,
} as const;
// Instance of construct indexed by id
class Storage extends AwsConstruct {
    public static type = "storage";
    public static create(scope: CdkConstruct, id: string, configuration: Record<string, unknown>): Storage {
        if (!isValidStorageConfiguration(configuration)) {
            throw new Error("Wrong configuration");
        }

        return new Storage(scope, id, configuration);
    }
    constructor(scope: CdkConstruct, id: string, configuration: FromSchema<typeof StorageSchema>) {
        super(StorageSchema, scope, id);

        new Bucket(this, "Bucket");
    }

    commands() {
        console.log("Here are commands specific to this instance");
    }
}

const isValidStorageConfiguration = (
    configuration: Record<string, unknown>
): configuration is FromSchema<typeof StorageSchema> => {
    return true;
};

const Constructs = { Storage };

export class AwsProvider {
    private readonly stack: Stack;
    constructor() {
        const app = new App();
        this.stack = new Stack(app);
    }

    public create(type: string, id: string): AwsConstruct {
        for (const Construct of Object.values(Constructs)) {
            if (Construct.type === type) {
                return Construct.create(this.stack, id, {});
            }
        }
        throw new Error("Undefined type of construct");
    }
}

export class Plugin {
    private readonly constructs: Record<string, ServerlessConstruct> = {};
    constructor() {
        const provider = new AwsProvider();
        const serverlessInputConfiguration = {
            avatars: {
                type: "storage",
            },
        };
        for (const [id, { type }] of Object.entries(serverlessInputConfiguration)) {
            this.constructs[id] = provider.create(id, type);
        }
    }
}

```