### PR TITLE
Implements the deprecated `variableResolvers` to make sure we display useful error messages to users

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,6 +9,7 @@ import { FromSchema } from "json-schema-to-ts";
 import type {
     CloudformationTemplate,
     CommandsDefinition,
+    DeprecatedVariableResolver,
     Hook,
     Serverless,
     VariableResolver,
@@ -56,8 +57,8 @@ class LiftPlugin {
     public readonly stack: Stack;
     public readonly hooks: Record<string, Hook>;
     public readonly commands: CommandsDefinition = {};
-    public readonly configurationVariablesSources: Record<string, VariableResolver> = {};
-    public variableResolvers: any;
+    public readonly configurationVariablesSources: Record<string, VariableResolver>;
+    public readonly variableResolvers: Record<string, DeprecatedVariableResolver>;
 
     constructor(serverless: Serverless) {
         this.app = new App();
@@ -89,7 +90,7 @@ class LiftPlugin {
             },
         };
         this.variableResolvers = {
-            construct: (fullVariable: string) => {
+            construct: (fullVariable) => {
                 const address = fullVariable.split(":")[1];
 
                 return Promise.resolve(this.resolveReference({ address }).value);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -57,6 +57,7 @@ class LiftPlugin {
     public readonly hooks: Record<string, Hook>;
     public readonly commands: CommandsDefinition = {};
     public readonly configurationVariablesSources: Record<string, VariableResolver> = {};
+    public variableResolvers: any;
 
     constructor(serverless: Serverless) {
         this.app = new App();
@@ -82,12 +83,16 @@ class LiftPlugin {
             "lift:eject:eject": this.eject.bind(this),
         };
 
-        // TODO variables should be resolved just before deploying each provider
-        // else we might get outdated values
         this.configurationVariablesSources = {
-            // TODO these 2 variable sources should be merged eventually
             construct: {
                 resolve: this.resolveReference.bind(this),
+            },
+        };
+        this.variableResolvers = {
+            construct: (fullVariable: string) => {
+                const address = fullVariable.split(":")[1];
+
+                return Promise.resolve(this.resolveReference({ address }).value);
             },
         };
 

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -19,6 +19,7 @@ export type VariableResolver = {
         options: Record<string, string>;
     }) => { value: string | Record<string, unknown> } | Promise<{ value: string | Record<string, unknown> }>;
 };
+export type DeprecatedVariableResolver = (variable: string) => Promise<Record<string, unknown>>;
 
 export type Provider = {
     naming: {


### PR DESCRIPTION
See for background https://github.com/serverless/serverless/issues/9610

Now when a variable fails to be resolved, the users see the actual error.

I think that could even be improved by using the `ServerlessError` class, but I have that in a separate branch for now.

Will add tests of variables separately from that.