### PR TITLE
Fixed typo on “construct“ variables (fixes #36)

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -47,10 +47,10 @@ functions:
     myFunction:
         handler: src/index.handler
         environment:
-            BUCKET_NAME: ${constructs:avatars.bucketName}
+            BUCKET_NAME: ${construct:avatars.bucketName}
 ```
 
-_How it works: the `${constructs:avatars.bucketName}` variable will automatically be replaced with a CloudFormation reference to the S3 bucket._
+_How it works: the `${construct:avatars.bucketName}` variable will automatically be replaced with a CloudFormation reference to the S3 bucket._
 
 ## Permissions
 
@@ -67,7 +67,7 @@ functions:
     myFunction:
         handler: src/index.handler
         environment:
-            BUCKET_NAME: ${constructs:avatars.bucketName}
+            BUCKET_NAME: ${construct:avatars.bucketName}
 ```
 
 ## Configuration reference

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -50,7 +50,7 @@ functions:
         handler: src/stripeConsumer.handler
         events:
             -   eventBridge:
-                    eventBus: ${constructs:stripe.busName}
+                    eventBus: ${construct:stripe.busName}
                     pattern:
                         source:
                             # filter all events received on stripe webhook
@@ -59,7 +59,7 @@ functions:
                             - invoice.paid
 ```
 
-_How it works: the `${constructs:stripe.busName}` variable will automatically be replaced with a CloudFormation reference to the EventBridge bus._
+_How it works: the `${construct:stripe.busName}` variable will automatically be replaced with a CloudFormation reference to the EventBridge bus._
 
 ## Configuration reference
 


### PR DESCRIPTION
Fixed typo in construct variables, removed the extra `s`.

This should fix #36.
