### PR TITLE
Added missing "type" configuration for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Deploy webhooks to receive notifications from 3rd party applications.
 ```yaml
 constructs:
     stripe-webhook:
+        type: webhook
         path: /my-webhook-endpoint
         authorizer:
             handler: myAuthorizer.main

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -12,6 +12,7 @@ provider:
 
 constructs:
     stripe:
+        type: webhook
         authorizer:
             handler: myAuthorizer.main
         path: /my-webhook-endpoint


### PR DESCRIPTION
Still trying each construct, I'm on the last: webhooks!

I copy/pasted the quick start to test webhooks and got an error:

```
  TypeError: Cannot read property 'class' of undefined
      at LiftPlugin.loadConstructs (/Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless-lift/dist/src/plugin.js:93:85)
      at new LiftPlugin (/Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless-lift/dist/src/plugin.js:83:10)
      at PluginManager.addPlugin (/Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless/lib/classes/PluginManager.js:112:28)
      at /Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless/lib/classes/PluginManager.js:158:33
      at Array.forEach (<anonymous>)
      at PluginManager.loadAllPlugins (/Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless/lib/classes/PluginManager.js:158:8)
      at Serverless.init (/Users/afu/Workspaces/LiveCoding/Lift/4-webhook/node_modules/serverless/lib/Serverless.js:206:30)
      at async Serverless.eventuallyFallbackToLocal (/snapshot/serverless/lib/Serverless.js:265:5)
      at async Serverless.init (/snapshot/serverless/lib/Serverless.js:194:5)
      at async /snapshot/serverless/scripts/serverless.js:441:7
```

I realized that the "type" property was missing for this construct, so here it is :wink: