### PR TITLE
Fix node10 compatibility

### DIFF
--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -21,6 +21,7 @@ import chalk from "chalk";
 import { CreateInvalidationRequest, CreateInvalidationResult } from "aws-sdk/clients/cloudfront";
 import { S3Origin } from "@aws-cdk/aws-cloudfront-origins";
 import * as acm from "@aws-cdk/aws-certificatemanager";
+import { flatten } from "lodash";
 import { log } from "../utils/logger";
 import { s3Sync } from "../utils/s3-sync";
 import AwsProvider from "../classes/AwsProvider";
@@ -86,7 +87,7 @@ export class StaticWebsite extends CdkConstruct implements Construct {
         bucket.grantRead(cloudFrontOAI);
 
         // Cast the domains to an array
-        const domains = configuration.domain !== undefined ? [configuration.domain].flat() : undefined;
+        const domains = configuration.domain !== undefined ? flatten([configuration.domain]) : undefined;
         const certificate =
             configuration.certificate !== undefined
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import { App, Stack } from "@aws-cdk/core";
-import { get, has, merge } from "lodash";
+import { flatten, get, has, merge } from "lodash";
 import chalk from "chalk";
 import { AwsIamPolicyStatements } from "@serverless/typescript";
 import * as path from "path";
@@ -191,11 +191,11 @@ class LiftPlugin {
     }
 
     private appendPermissions(): void {
-        const statements = Object.entries(this.constructs)
-            .map(([, construct]) => {
+        const statements = flatten(
+            Object.entries(this.constructs).map(([, construct]) => {
                 return ((construct.permissions ? construct.permissions() : []) as unknown) as AwsIamPolicyStatements;
             })
-            .flat(1);
+        );
         if (statements.length === 0) {
             return;
         }

--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -12,7 +12,7 @@ import * as util from "util";
 import * as path from "path";
 import * as crypto from "crypto";
 import { lookup } from "mime-types";
-import { chunk } from "lodash";
+import { chunk, flatten } from "lodash";
 import chalk from "chalk";
 import AwsProvider from "../classes/AwsProvider";
 
@@ -96,7 +96,7 @@ async function listFilesRecursively(directory: string): Promise<string[]> {
         })
     );
 
-    return files.flat(1);
+    return flatten(files);
 }
 
 async function s3ListAll(aws: AwsProvider, bucketName: string): Promise<S3Objects> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "strict": true,
     "target": "es2017",
-    "lib": ["ESNext"],
+    "lib": ["es2017"],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Use lodash flatten instead of Array.prototype.flat to fix the issue.

To prevent future issues, I lowered ts lib to match runtime requirements.

Fix: #38 