### PR TITLE
fix: allow to use the new provider.iam.role.statements

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -200,10 +200,10 @@ class LiftPlugin {
             return;
         }
 
-        if (this.serverless.service.provider.iam?.role?.statements !== undefined) {
-            this.serverless.service.provider.iam.role.statements.push(...statements);
+        const role = this.serverless.service.provider.iam?.role;
 
-            return;
+        if (typeof role === "object" && "statements" in role) {
+            role.statements?.push(...statements);
         }
 
         this.serverless.service.provider.iamRoleStatements = this.serverless.service.provider.iamRoleStatements ?? [];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -204,6 +204,8 @@ class LiftPlugin {
 
         if (typeof role === "object" && "statements" in role) {
             role.statements?.push(...statements);
+
+            return;
         }
 
         this.serverless.service.provider.iamRoleStatements = this.serverless.service.provider.iamRoleStatements ?? [];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -199,6 +199,13 @@ class LiftPlugin {
         if (statements.length === 0) {
             return;
         }
+
+        if (this.serverless.service.provider.iam?.role?.statements !== undefined) {
+            this.serverless.service.provider.iam.role.statements.push(...statements);
+
+            return;
+        }
+
         this.serverless.service.provider.iamRoleStatements = this.serverless.service.provider.iamRoleStatements ?? [];
         this.serverless.service.provider.iamRoleStatements.push(...statements);
     }

--- a/test/fixtures/permissions/serverless.yml
+++ b/test/fixtures/permissions/serverless.yml
@@ -1,0 +1,13 @@
+service: storage
+configValidationMode: error
+
+provider:
+  name: aws
+
+functions:
+  foo:
+    handler: worker.handler
+
+constructs:
+  testStorage:
+    type: storage

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -1,0 +1,62 @@
+import { get, merge } from "lodash";
+import { pluginConfigExt, runServerless } from "../utils/runServerless";
+
+describe("permissions", () => {
+    it("should not override user-defined role", async () => {
+        const { cfTemplate } = await runServerless({
+            fixture: "permissions",
+            configExt: merge(pluginConfigExt, {
+                provider: {
+                    iam: {
+                        role: "arn:aws:iam::123456789012:role/role",
+                    },
+                },
+            }),
+            cliArgs: ["package"],
+        });
+        expect(cfTemplate.Resources.FooLambdaFunction).toMatchObject({
+            Properties: {
+                Role: "arn:aws:iam::123456789012:role/role",
+            },
+        });
+    });
+
+    it("should append permissions when using the deprecated iamRoleStatements", async () => {
+        const { cfTemplate } = await runServerless({
+            fixture: "permissions",
+            configExt: merge(pluginConfigExt, {
+                provider: {
+                    iam: {
+                        role: {
+                            statements: [
+                                {
+                                    Effect: "Allow",
+                                    Action: ["dynamodb:PutItem"],
+                                    Resource: "arn:aws:dynamodb:us-east-1:123456789012:table/myDynamoDBTable",
+                                },
+                            ],
+                        },
+                    },
+                },
+            }),
+            cliArgs: ["package"],
+        });
+        expect(
+            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
+        ).toContainEqual({
+            Effect: "Allow",
+            Action: ["dynamodb:PutItem"],
+            Resource: "arn:aws:dynamodb:us-east-1:123456789012:table/myDynamoDBTable",
+        });
+        expect(
+            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
+        ).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    Effect: "Allow",
+                    Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
+                }),
+            ])
+        );
+    });
+});

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -1,11 +1,37 @@
 import { get, merge } from "lodash";
 import { pluginConfigExt, runServerless } from "../utils/runServerless";
 
+type CfTemplate = {
+    Resources: Record<string, unknown>;
+    Outputs?: Record<string, unknown>;
+};
+
+function expectLiftStorageStatementIsAdded(cfTemplate: CfTemplate) {
+    expect(get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                Effect: "Allow",
+                Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
+            }),
+        ])
+    );
+}
+
+function expectUserDynamoStatementIsAdded(cfTemplate: CfTemplate) {
+    expect(
+        get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
+    ).toContainEqual({
+        Effect: "Allow",
+        Action: ["dynamodb:PutItem"],
+        Resource: "arn:aws:dynamodb:us-east-1:123456789012:table/myDynamoDBTable",
+    });
+}
+
 describe("permissions", () => {
     it("should not override user-defined role", async () => {
         const { cfTemplate } = await runServerless({
             fixture: "permissions",
-            configExt: merge(pluginConfigExt, {
+            configExt: merge({}, pluginConfigExt, {
                 provider: {
                     iam: {
                         role: "arn:aws:iam::123456789012:role/role",
@@ -21,10 +47,10 @@ describe("permissions", () => {
         });
     });
 
-    it("should append permissions when using the deprecated iamRoleStatements", async () => {
+    it("should append permissions when using iam.role.statements", async () => {
         const { cfTemplate } = await runServerless({
             fixture: "permissions",
-            configExt: merge(pluginConfigExt, {
+            configExt: merge({}, pluginConfigExt, {
                 provider: {
                     iam: {
                         role: {
@@ -41,22 +67,39 @@ describe("permissions", () => {
             }),
             cliArgs: ["package"],
         });
-        expect(
-            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
-        ).toContainEqual({
-            Effect: "Allow",
-            Action: ["dynamodb:PutItem"],
-            Resource: "arn:aws:dynamodb:us-east-1:123456789012:table/myDynamoDBTable",
+
+        expectUserDynamoStatementIsAdded(cfTemplate);
+        expectLiftStorageStatementIsAdded(cfTemplate);
+    });
+
+    it("should append permissions when using the deprecated iamRoleStatements", async () => {
+        const { cfTemplate } = await runServerless({
+            fixture: "permissions",
+            configExt: merge({}, pluginConfigExt, {
+                provider: {
+                    iamRoleStatements: [
+                        {
+                            Effect: "Allow",
+                            Action: ["dynamodb:PutItem"],
+                            Resource: "arn:aws:dynamodb:us-east-1:123456789012:table/myDynamoDBTable",
+                        },
+                    ],
+                },
+            }),
+            cliArgs: ["package"],
         });
-        expect(
-            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
-        ).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    Effect: "Allow",
-                    Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
-                }),
-            ])
-        );
+
+        expectUserDynamoStatementIsAdded(cfTemplate);
+        expectLiftStorageStatementIsAdded(cfTemplate);
+    });
+
+    it("should add permissions when no custom statements are provided", async () => {
+        const { cfTemplate } = await runServerless({
+            fixture: "permissions",
+            configExt: pluginConfigExt,
+            cliArgs: ["package"],
+        });
+
+        expectLiftStorageStatementIsAdded(cfTemplate);
     });
 });


### PR DESCRIPTION
Should fix https://github.com/getlift/lift/issues/47

Here we add to `provider.iam.role.statements` if it exists or add to `provider.iamRoleStatements` if not (so that we are still backward-compatible with older versions of the serverless framework.

TODO
* [x] Test it 
* [x] Fix the type issue
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->
