### PR TITLE
Instantiate constructs after all variables are resolved

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 /lib
 /dist
 /utils
+/test/fixtures

--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,9 @@
         "@typescript-eslint/no-unnecessary-condition": "error",
         "@typescript-eslint/no-unnecessary-type-arguments": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
-        "@typescript-eslint/switch-exhaustiveness-check": "error"
+        "@typescript-eslint/switch-exhaustiveness-check": "error",
+        // We intentionally use this so that constructs can declare their command handlers
+        "@typescript-eslint/unbound-method": "off"
       }
     }
   ]

--- a/src/classes/AwsConstruct.ts
+++ b/src/classes/AwsConstruct.ts
@@ -26,8 +26,6 @@ export abstract class AwsConstruct extends CdkConstruct implements ConstructInte
 
     abstract outputs(): Record<string, () => Promise<string | undefined>>;
 
-    abstract commands(): Record<string, () => void | Promise<void>>;
-
     /**
      * CloudFormation references
      */

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -72,9 +72,6 @@ export class AwsProvider {
             this.serverless.configurationInput.functions = {};
         }
 
-        Object.assign(this.serverless.configurationInput.functions, {
-            [functionName]: functionConfig,
-        });
         Object.assign(this.serverless.service.functions, {
             [functionName]: functionConfig,
         });

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -75,6 +75,9 @@ export class AwsProvider {
         Object.assign(this.serverless.configurationInput.functions, {
             [functionName]: functionConfig,
         });
+        Object.assign(this.serverless.service.functions, {
+            [functionName]: functionConfig,
+        });
         /**
          * We must manually call `setFunctionNames()`: this is a function that normalizes functions.
          * This function is called by the Framework, but we have to call it again because we add new

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -70,6 +70,13 @@ export class AwsProvider {
         Object.assign(this.serverless.service.functions, {
             [functionName]: functionConfig,
         });
+        /**
+         * We must manually call `setFunctionNames()`: this is a function that normalizes functions.
+         * This function is called by the Framework, but we have to call it again because we add new
+         * functions after this function has already run. So our new function (that we add here)
+         * will not have been normalized.
+         */
+        this.serverless.service.setFunctionNames(this.serverless.processedInput.options);
     }
 
     /**

--- a/src/classes/Construct.ts
+++ b/src/classes/Construct.ts
@@ -7,8 +7,6 @@ import { AwsProvider } from "./AwsProvider";
 export interface ConstructInterface {
     outputs(): Record<string, () => Promise<string | undefined>>;
 
-    commands(): Record<string, () => void | Promise<void>>;
-
     /**
      * CloudFormation references
      */
@@ -39,5 +37,19 @@ export interface StaticConstructInterface {
         type: "object";
         [k: string]: unknown;
     };
+    commands?(): ConstructCommands;
     create(provider: AwsProvider, id: string, configuration: Record<string, unknown>): ConstructInterface;
 }
+
+export type ConstructCommands = Record<string, ConstructCommandDefinition>;
+type ConstructCommandDefinition = {
+    usage: string;
+    handler: (opt: Record<string, string>) => void | Promise<void>;
+    options?: {
+        [name: string]: {
+            usage: string;
+            required: boolean;
+            shortcut?: string;
+        };
+    };
+};

--- a/src/classes/Construct.ts
+++ b/src/classes/Construct.ts
@@ -37,7 +37,7 @@ export interface StaticConstructInterface {
         type: "object";
         [k: string]: unknown;
     };
-    commands?(): ConstructCommands;
+    commands?: ConstructCommands;
     create(provider: AwsProvider, id: string, configuration: Record<string, unknown>): ConstructInterface;
 }
 

--- a/src/constructs/Queue.ts
+++ b/src/constructs/Queue.ts
@@ -42,22 +42,20 @@ type Configuration = FromSchema<typeof QUEUE_DEFINITION>;
 export class Queue extends AwsConstruct {
     public static type = "queue";
     public static schema = QUEUE_DEFINITION;
-    public static commands(): ConstructCommands {
-        return {
-            failed: {
-                usage: "List failed messages from the dead letter queue.",
-                handler: Queue.prototype.listDlq,
-            },
-            "failed:purge": {
-                usage: "Purge failed messages from the dead letter queue.",
-                handler: Queue.prototype.purgeDlq,
-            },
-            "failed:retry": {
-                usage: "Retry failed messages from the dead letter queue by moving them to the main queue.",
-                handler: Queue.prototype.retryDlq,
-            },
-        };
-    }
+    public static commands: ConstructCommands = {
+        failed: {
+            usage: "List failed messages from the dead letter queue.",
+            handler: Queue.prototype.listDlq,
+        },
+        "failed:purge": {
+            usage: "Purge failed messages from the dead letter queue.",
+            handler: Queue.prototype.purgeDlq,
+        },
+        "failed:retry": {
+            usage: "Retry failed messages from the dead letter queue by moving them to the main queue.",
+            handler: Queue.prototype.retryDlq,
+        },
+    };
 
     private readonly queue: CdkQueue;
     private readonly queueArnOutput: CfnOutput;

--- a/src/constructs/Queue.ts
+++ b/src/constructs/Queue.ts
@@ -11,6 +11,7 @@ import { AwsConstruct, AwsProvider } from "../classes";
 import { pollMessages, retryMessages } from "./queue/sqs";
 import { sleep } from "../utils/sleep";
 import { PolicyStatement } from "../CloudFormation";
+import { ConstructCommands } from "../classes/Construct";
 
 const QUEUE_DEFINITION = {
     type: "object",
@@ -41,6 +42,22 @@ type Configuration = FromSchema<typeof QUEUE_DEFINITION>;
 export class Queue extends AwsConstruct {
     public static type = "queue";
     public static schema = QUEUE_DEFINITION;
+    public static commands(): ConstructCommands {
+        return {
+            failed: {
+                usage: "List failed messages from the dead letter queue.",
+                handler: Queue.prototype.listDlq,
+            },
+            "failed:purge": {
+                usage: "Purge failed messages from the dead letter queue.",
+                handler: Queue.prototype.purgeDlq,
+            },
+            "failed:retry": {
+                usage: "Retry failed messages from the dead letter queue by moving them to the main queue.",
+                handler: Queue.prototype.retryDlq,
+            },
+        };
+    }
 
     private readonly queue: CdkQueue;
     private readonly queueArnOutput: CfnOutput;
@@ -128,14 +145,6 @@ export class Queue extends AwsConstruct {
         });
 
         this.appendFunctions();
-    }
-
-    commands(): Record<string, () => void | Promise<void>> {
-        return {
-            failed: () => this.listDlq(),
-            "failed:purge": () => this.purgeDlq(),
-            "failed:retry": () => this.retryDlq(),
-        };
     }
 
     outputs(): Record<string, () => Promise<string | undefined>> {

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -60,14 +60,12 @@ type Configuration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;
 export class StaticWebsite extends AwsConstruct {
     public static type = "static-website";
     public static schema = STATIC_WEBSITE_DEFINITION;
-    public static commands(): ConstructCommands {
-        return {
-            upload: {
-                usage: "Upload files directly to S3 without going through a CloudFormation deployment.",
-                handler: StaticWebsite.prototype.uploadWebsite,
-            },
-        };
-    }
+    public static commands: ConstructCommands = {
+        upload: {
+            usage: "Upload files directly to S3 without going through a CloudFormation deployment.",
+            handler: StaticWebsite.prototype.uploadWebsite,
+        },
+    };
 
     private readonly bucketNameOutput: CfnOutput;
     private readonly domainOutput: CfnOutput;

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -25,6 +25,7 @@ import { flatten } from "lodash";
 import { log } from "../utils/logger";
 import { s3Sync } from "../utils/s3-sync";
 import { AwsConstruct, AwsProvider } from "../classes";
+import { ConstructCommands } from "../classes/Construct";
 import ServerlessError from "../utils/error";
 
 const STATIC_WEBSITE_DEFINITION = {
@@ -59,6 +60,14 @@ type Configuration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;
 export class StaticWebsite extends AwsConstruct {
     public static type = "static-website";
     public static schema = STATIC_WEBSITE_DEFINITION;
+    public static commands(): ConstructCommands {
+        return {
+            upload: {
+                usage: "Upload files directly to S3 without going through a CloudFormation deployment.",
+                handler: StaticWebsite.prototype.uploadWebsite,
+            },
+        };
+    }
 
     private readonly bucketNameOutput: CfnOutput;
     private readonly domainOutput: CfnOutput;
@@ -155,12 +164,6 @@ export class StaticWebsite extends AwsConstruct {
             description: "ID of the CloudFront distribution.",
             value: distribution.distributionId,
         });
-    }
-
-    commands(): Record<string, () => Promise<void>> {
-        return {
-            upload: this.uploadWebsite.bind(this),
-        };
     }
 
     outputs(): Record<string, () => Promise<string | undefined>> {

--- a/src/constructs/Storage.ts
+++ b/src/constructs/Storage.ts
@@ -85,10 +85,6 @@ export class Storage extends AwsConstruct {
         ];
     }
 
-    commands(): Record<string, () => void | Promise<void>> {
-        return {};
-    }
-
     outputs(): Record<string, () => Promise<string | undefined>> {
         return {
             bucketName: () => this.getBucketName(),

--- a/src/constructs/Webhook.ts
+++ b/src/constructs/Webhook.ts
@@ -141,10 +141,6 @@ export class Webhook extends AwsConstruct {
         this.appendFunctions();
     }
 
-    commands(): Record<string, () => void | Promise<void>> {
-        return {};
-    }
-
     outputs(): Record<string, () => Promise<string | undefined>> {
         return {
             httpMethod: () => this.getHttpMethod(),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -286,6 +286,8 @@ class LiftPlugin {
         this.serverless.service.functions = resolveTokens(this.serverless.service.functions);
         this.serverless.service.layers = resolveTokens(this.serverless.service.layers);
         this.serverless.service.outputs = resolveTokens(this.serverless.service.outputs);
+        // Also resolve tokens in `configurationInput` because they also appear in there
+        this.serverless.configurationInput = resolveTokens(this.serverless.configurationInput);
     }
 
     private appendCloudformationResources() {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -225,7 +225,7 @@ class LiftPlugin {
                 continue;
             }
             // For each command of the construct
-            for (const [command, commandDefinition] of Object.entries(constructClass.commands())) {
+            for (const [command, commandDefinition] of Object.entries(constructClass.commands)) {
                 this.commands[`${id}:${command}`] = {
                     lifecycleEvents: [command],
                     usage: commandDefinition.usage,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -274,9 +274,10 @@ class LiftPlugin {
             }) as T;
         };
         this.serverless.service.provider = resolveTokens(this.serverless.service.provider);
-        this.serverless.service.functions = resolveTokens(this.serverless.service.functions);
+        this.serverless.service.package = resolveTokens(this.serverless.service.package);
         this.serverless.service.custom = resolveTokens(this.serverless.service.custom);
         this.serverless.service.resources = resolveTokens(this.serverless.service.resources);
+        this.serverless.service.functions = resolveTokens(this.serverless.service.functions);
         this.serverless.service.layers = resolveTokens(this.serverless.service.layers);
         this.serverless.service.outputs = resolveTokens(this.serverless.service.outputs);
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -176,10 +176,16 @@ class LiftPlugin {
 
                     const properties = construct.references();
                     if (!has(properties, property)) {
+                        if (Object.keys(properties).length === 0) {
+                            throw new ServerlessError(
+                                `\${construct:${id}.${property}} does not exist. The construct '${id}' does not expose any property`,
+                                "LIFT_VARIABLE_UNKNOWN_PROPERTY"
+                            );
+                        }
                         throw new ServerlessError(
                             `\${construct:${id}.${property}} does not exist. Properties available on \${construct:${id}} are: ${Object.keys(
                                 properties
-                            ).join(", ")}.`,
+                            ).join(", ")}`,
                             "LIFT_VARIABLE_UNKNOWN_PROPERTY"
                         );
                     }

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -45,7 +45,13 @@ export type Serverless = {
         defineTopLevelProperty: (pluginName: string, schema: Record<string, unknown>) => void;
     };
     configurationInput: AWS & { constructs?: Record<string, { type: string }> };
-    service: AWS;
+    service: AWS & {
+        setFunctionNames(rawOptions: Record<string, unknown>): void;
+    };
+    processedInput: {
+        commands: unknown;
+        options: Record<string, unknown>;
+    };
     getProvider: (provider: "aws") => Provider;
 };
 

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -18,7 +18,7 @@ export type VariableResolver = {
         options: Record<string, string>;
     }) => { value: string | Record<string, unknown> } | Promise<{ value: string | Record<string, unknown> }>;
 };
-export type DeprecatedVariableResolver = (variable: string) => Promise<Record<string, unknown>>;
+export type DeprecatedVariableResolver = (variable: string) => Promise<string | Record<string, unknown>>;
 
 export type Provider = {
     naming: {
@@ -51,4 +51,18 @@ export type Serverless = {
 
 export type CloudformationTemplate = AWS["resources"];
 
-export type CommandsDefinition = Record<string, { lifecycleEvents?: string[]; commands?: CommandsDefinition }>;
+export type CommandsDefinition = Record<
+    string,
+    {
+        lifecycleEvents?: string[];
+        commands?: CommandsDefinition;
+        usage?: string;
+        options?: {
+            [name: string]: {
+                usage: string;
+                required: boolean;
+                shortcut?: string;
+            };
+        };
+    }
+>;

--- a/test/fixtures/variables/extra-plugin.js
+++ b/test/fixtures/variables/extra-plugin.js
@@ -20,6 +20,17 @@ module.exports = class ExtraPlugin {
                     };
                 },
             },
+            "custom-arn": {
+                // Async resolver replicating the Dashboard Plugin implementation
+                // https://github.com/serverless/dashboard-plugin/blob/ea662fcf03e8f2f5c1f435d24249c72025a24dbf/lib/plugin.js#L180-L194
+                async resolve() {
+                    return {
+                        value: await (async () => {
+                            return Promise.resolve("arn:aws:acm:us-east-1:123466615250:certificate/abcdef-b896-4725-96e3-6f143d06ac0b");
+                        })(),
+                    };
+                },
+            },
         };
         // Old variable mechanism
         this.variableResolvers = {

--- a/test/fixtures/variables/serverless.yml
+++ b/test/fixtures/variables/serverless.yml
@@ -29,7 +29,7 @@ constructs:
     type: static-website
     path: dist
     domain: ${custom-var-1:foo}
-    certificate: ${custom-var-2:foo}
+    certificate: ${custom-arn:foo}
 
 resources:
   Resources:

--- a/test/fixtures/variables/serverless.yml
+++ b/test/fixtures/variables/serverless.yml
@@ -6,12 +6,14 @@ provider:
 
 custom:
   foo: bar
+  variable: ${construct:bucket.bucketName}
 
 functions:
   foo:
     handler: worker.handler
     environment:
       VAR1: ${construct:bar.queueUrl}
+      CUSTOM_VAR: ${self:custom.variable}
 
 constructs:
   bar:
@@ -25,11 +27,15 @@ constructs:
         CUSTOM_VAR2: ${custom-var-2:foo}
         CUSTOM_VAR3: ${custom-var-3:foo}
         CUSTOM_VAR4: ${custom-var-4:foo}
+    # Test a variable of another construct
+    alarm: ${construct:bucket.bucketName}
   app:
     type: static-website
     path: dist
     domain: ${custom-var-1:foo}
     certificate: ${custom-arn:foo}
+  bucket:
+    type: storage
 
 resources:
   Resources:

--- a/test/unit/common.test.ts
+++ b/test/unit/common.test.ts
@@ -1,5 +1,4 @@
 import { baseConfig, pluginConfigExt, runServerless } from "../utils/runServerless";
-import { runServerlessCli } from "../utils/runServerlessCli";
 
 describe("common", () => {
     it("should not override user defined resources in serverless.yml", async () => {
@@ -54,57 +53,5 @@ describe("common", () => {
                 }),
             })
         ).rejects.toThrow("Configuration error at 'constructs.avatars': unsupported value");
-    });
-
-    it("should resolve variables", async () => {
-        const { cfTemplate } = await runServerlessCli({
-            fixture: "variables",
-            command: "package",
-        });
-        // Resolves construct variables in `functions`
-        expect(cfTemplate.Resources.FooLambdaFunction).toMatchObject({
-            Properties: {
-                Environment: {
-                    Variables: {
-                        VAR1: {
-                            Ref: "barQueueB989EBF4",
-                        },
-                    },
-                },
-            },
-        });
-        // Resolves Framework variables in `constructs`
-        expect(cfTemplate.Resources.BarWorkerLambdaFunction).toMatchObject({
-            Properties: {
-                Environment: {
-                    Variables: {
-                        VAR1: "bar",
-                        CUSTOM_VAR1: "Custom variable 1",
-                        CUSTOM_VAR2: "Custom variable 2",
-                        CUSTOM_VAR3: "Custom variable 3",
-                        CUSTOM_VAR4: "Custom variable 4",
-                    },
-                },
-            },
-        });
-        expect(cfTemplate.Resources.appCDN7AD2C001).toMatchObject({
-            Properties: {
-                DistributionConfig: {
-                    Aliases: ["Custom variable 1"],
-                    ViewerCertificate: {
-                        AcmCertificateArn:
-                            "arn:aws:acm:us-east-1:123466615250:certificate/abcdef-b896-4725-96e3-6f143d06ac0b",
-                    },
-                },
-            },
-        });
-        // Resolves construct variables in `resources`
-        expect(cfTemplate.Resources.UserDefinedResource).toMatchObject({
-            Properties: {
-                BucketName: {
-                    Ref: "barQueueB989EBF4",
-                },
-            },
-        });
     });
 });

--- a/test/unit/common.test.ts
+++ b/test/unit/common.test.ts
@@ -49,7 +49,8 @@ describe("common", () => {
                 DistributionConfig: {
                     Aliases: ["Custom variable 1"],
                     ViewerCertificate: {
-                        AcmCertificateArn: "Custom variable 2",
+                        AcmCertificateArn:
+                            "arn:aws:acm:us-east-1:123466615250:certificate/abcdef-b896-4725-96e3-6f143d06ac0b",
                     },
                 },
             },

--- a/test/unit/variables.test.ts
+++ b/test/unit/variables.test.ts
@@ -1,0 +1,53 @@
+import { runServerlessCli } from "../utils/runServerlessCli";
+
+describe("variables", () => {
+    it("should resolve construct variables", async () => {
+        const { cfTemplate } = await runServerlessCli({
+            fixture: "variables",
+            command: "package",
+        });
+        // Resolves construct variables in `functions`
+        expect(cfTemplate.Resources.FooLambdaFunction).toHaveProperty("Properties.Environment.Variables.VAR1", {
+            Ref: "barQueueB989EBF4",
+        });
+        // Resolves construct variables in `resources`
+        expect(cfTemplate.Resources.UserDefinedResource).toHaveProperty("Properties.BucketName", {
+            Ref: "barQueueB989EBF4",
+        });
+        // Resolves construct variables in `custom`
+        expect(cfTemplate.Resources.FooLambdaFunction).toHaveProperty("Properties.Environment.Variables.CUSTOM_VAR", {
+            Ref: "bucketBucketF19722A9",
+        });
+    });
+
+    it("should resolve variables in constructs", async () => {
+        const { cfTemplate } = await runServerlessCli({
+            fixture: "variables",
+            command: "package",
+        });
+        expect(cfTemplate.Resources.BarWorkerLambdaFunction).toHaveProperty("Properties.Environment.Variables", {
+            // Native serverless variable
+            VAR1: "bar",
+            // Custom variables defined by plugins (using a different API every time
+            CUSTOM_VAR1: "Custom variable 1",
+            CUSTOM_VAR2: "Custom variable 2",
+            CUSTOM_VAR3: "Custom variable 3",
+            CUSTOM_VAR4: "Custom variable 4",
+        });
+        // ${construct:bucket.bucketName} should have been resolved
+        expect(cfTemplate.Resources.barAlarmTopicSubscription56286022).toHaveProperty("Properties.Endpoint", {
+            Ref: "bucketBucketF19722A9",
+        });
+        expect(cfTemplate.Resources.appCDN7AD2C001).toMatchObject({
+            Properties: {
+                DistributionConfig: {
+                    Aliases: ["Custom variable 1"],
+                    ViewerCertificate: {
+                        AcmCertificateArn:
+                            "arn:aws:acm:us-east-1:123466615250:certificate/abcdef-b896-4725-96e3-6f143d06ac0b",
+                    },
+                },
+            },
+        });
+    });
+});


### PR DESCRIPTION
Fix #29.

Replaces #31.

On master:

- constructs are instantiated in the constructor of the Lift plugin
- that means that variables resolved _after_ the Lift plugin is instantiated are not resolved in constructs

In this branch:

- constructs are instantiated in the `initialize` hook (at this point, all variables are resolved)
- to achieve that, commands are now defined statically
- and Lift variables are resolved lazily using CDK tokens (CDK lazy variables)

This PR includes #41 (the test that reproduces the problem).

TODO:

- [x] additional testing