### PR TITLE
[Static Website] Add new `errorPage` configuration

### DIFF
--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -162,6 +162,23 @@ constructs:
             - app.mywebsite.com
 ```
 
+### Error page
+
+By default, all 404 requests are redirected to `index.html` with a 200 response status. This behavior is optimized for Single-Page Applications: it allows doing client-side URL routing with JavaScript frameworks.
+
+For static websites that _are not SPA_, it is possible to serve a custom "Not found" error page:
+
+```yaml
+constructs:
+    landing:
+        # ...
+        errorPage: error.html # can be any HTML file in your project
+```
+
+When a browser requests the URL of a non-existing file, the `error.html` file will be served with a 404 response status.
+
+Do not use this setting when doing JavaScript URL routing: this will break URL routing.
+
 ### Allow iframes
 
 By default, as recommended [for security reasons](https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options), the static website cannot be embedded in an iframe.

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -276,6 +276,13 @@ export class StaticWebsite extends AwsConstruct {
         // Custom error page
         if (this.configuration.errorPage !== undefined) {
             let errorPath = this.configuration.errorPage;
+            if (errorPath.startsWith("./") || errorPath.startsWith("../")) {
+                throw new ServerlessError(
+                    `The 'errorPage' option of the '${this.id}' static website cannot start with './' or '../'. ` +
+                        `(it cannot be a relative path).`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
             if (!errorPath.startsWith("/")) {
                 errorPath = `/${errorPath}`;
             }

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -22,6 +22,7 @@ import { CreateInvalidationRequest, CreateInvalidationResult } from "aws-sdk/cli
 import { S3Origin } from "@aws-cdk/aws-cloudfront-origins";
 import * as acm from "@aws-cdk/aws-certificatemanager";
 import { flatten } from "lodash";
+import { ErrorResponse } from "@aws-cdk/aws-cloudfront/lib/distribution";
 import { log } from "../utils/logger";
 import { s3Sync } from "../utils/s3-sync";
 import { AwsConstruct, AwsProvider } from "../classes";
@@ -49,6 +50,7 @@ const STATIC_WEBSITE_DEFINITION = {
             },
             additionalProperties: false,
         },
+        errorPage: { type: "string" },
     },
     additionalProperties: false,
     required: ["path"],
@@ -118,15 +120,7 @@ export class StaticWebsite extends AwsConstruct {
                     },
                 ],
             },
-            // For SPA we need dynamic pages to be served by index.html
-            errorResponses: [
-                {
-                    httpStatus: 404,
-                    ttl: Duration.seconds(0),
-                    responseHttpStatus: 200,
-                    responsePagePath: "/index.html",
-                },
-            ],
+            errorResponses: [this.errorResponse()],
             // Enable http2 transfer for better performances
             httpVersion: HttpVersion.HTTP2,
             certificate: certificate,
@@ -276,6 +270,34 @@ export class StaticWebsite extends AwsConstruct {
 
     async getDistributionId(): Promise<string | undefined> {
         return this.provider.getStackOutput(this.distributionIdOutput);
+    }
+
+    private errorResponse(): ErrorResponse {
+        // Custom error page
+        if (this.configuration.errorPage !== undefined) {
+            let errorPath = this.configuration.errorPage;
+            if (!errorPath.startsWith("/")) {
+                errorPath = `/${errorPath}`;
+            }
+
+            return {
+                httpStatus: 404,
+                ttl: Duration.seconds(0),
+                responseHttpStatus: 404,
+                responsePagePath: errorPath,
+            };
+        }
+
+        /**
+         * The default behavior is optimized for SPA: all unknown URLs are served
+         * by index.html so that routing can be done client-side.
+         */
+        return {
+            httpStatus: 404,
+            ttl: Duration.seconds(0),
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+        };
     }
 
     private createResponseFunction(): cloudfront.Function {

--- a/test/unit/staticWebsites.test.ts
+++ b/test/unit/staticWebsites.test.ts
@@ -339,6 +339,41 @@ describe("static websites", () => {
         });
     });
 
+    it("should validate the error page path", async () => {
+        await expect(() => {
+            return runServerless({
+                cliArgs: ["package"],
+                config: Object.assign(baseConfig, {
+                    constructs: {
+                        landing: {
+                            type: "static-website",
+                            path: ".",
+                            errorPage: "./error.html",
+                        },
+                    },
+                }),
+            });
+        }).rejects.toThrowError(
+            "The 'errorPage' option of the 'landing' static website cannot start with './' or '../'. (it cannot be a relative path)."
+        );
+        await expect(() => {
+            return runServerless({
+                cliArgs: ["package"],
+                config: Object.assign(baseConfig, {
+                    constructs: {
+                        landing: {
+                            type: "static-website",
+                            path: ".",
+                            errorPage: "../error.html",
+                        },
+                    },
+                }),
+            });
+        }).rejects.toThrowError(
+            "The 'errorPage' option of the 'landing' static website cannot start with './' or '../'. (it cannot be a relative path)."
+        );
+    });
+
     it("should synchronize files to S3", async () => {
         const awsMock = mockAws();
         sinon.stub(CloudFormationHelpers, "getStackOutput").resolves("bucket-name");

--- a/test/unit/staticWebsites.test.ts
+++ b/test/unit/staticWebsites.test.ts
@@ -306,6 +306,39 @@ describe("static websites", () => {
         });
     });
 
+    it("should allow to customize the error page", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            cliArgs: ["package"],
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "static-website",
+                        path: ".",
+                        // We do not set a leading `/` on purpose: we want to check
+                        // that Lift will add it
+                        errorPage: "my/custom/error.html",
+                    },
+                },
+            }),
+        });
+        const cfDistributionLogicalId = computeLogicalId("landing", "CDN");
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Properties: {
+                DistributionConfig: {
+                    CustomErrorResponses: [
+                        {
+                            // The response code is forced to 404 and changed to /error.html
+                            ErrorCachingMinTTL: 0,
+                            ErrorCode: 404,
+                            ResponseCode: 404,
+                            ResponsePagePath: "/my/custom/error.html",
+                        },
+                    ],
+                },
+            },
+        });
+    });
+
     it("should synchronize files to S3", async () => {
         const awsMock = mockAws();
         sinon.stub(CloudFormationHelpers, "getStackOutput").resolves("bucket-name");


### PR DESCRIPTION
At the moment, `static-website` redirects all 404 to `index.html`. This is perfect for SPA with routing in the browser (e.g. with react router or vue router): we want all unknown URLs to load the JS app.

However, this doesn't really work with flat static websites (without client-side routing).

This PR introduces a new `errorPage` option:

```yaml
constructs:
    landing:
        type: static-website
        # ...
        errorPage: error.html
```

- when not set, `static-website` is optimized for SPA and redirects 404s to `index.html` with a 200 response
- when set, 404s serve the error page (and keep a 404 response)

> Why go with the "SPA" behavior by default? Why not respond `404` responses by default?

The default error response for S3 is extremely ugly:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/720328/122777985-daae5c80-d2ac-11eb-92b0-2eede780c625.png">

This cannot be considered a good "production-ready default". So the default config could be a choice between:

1. serving a default error HTML page provided by Lift (like a 404 Netlify page)
2. enable the SPA behavior by default

In case of 1, that means that users building SPA would have to enable a new option to get SPA behavior -> I think this could be the most popular use case, compared to flat file websites. That's why I think enabling the SPA behavior by default makes sense.

After all, anyone building a flat-file static website will want to customize the error page anyway, right?