### PR TITLE
[RFC] Deploy any CDK construct | v2

### DIFF
--- a/src/classes/Construct.ts
+++ b/src/classes/Construct.ts
@@ -1,5 +1,6 @@
 import { PolicyStatement } from "../CloudFormation";
 import { AwsProvider } from "./AwsProvider";
+import ServerlessError from "../utils/error";
 import { CliOptions } from "../types/serverless";
 
 /**
@@ -55,3 +56,37 @@ type ConstructCommandDefinition = {
         };
     };
 };
+
+export function assertValidConstructClass(constructClass: unknown): asserts constructClass is StaticConstructInterface {
+    if (typeof constructClass !== "function") {
+        throw new ServerlessError(
+            `Tried to register a construct that is not an object. The construct is of type '${typeof constructClass}'`,
+            "LIFT_CONSTRUCT_INVALID_OBJECT"
+        );
+    }
+    // Type
+    if (!hasProperty(constructClass, "type") || typeof constructClass.type !== "string") {
+        throw new ServerlessError(
+            `The construct '${constructClass.constructor.name}' does not expose a static 'type' string property. ` +
+                "All constructs must expose a type name via a 'type' property.",
+            "LIFT_CONSTRUCT_MISSING_TYPE"
+        );
+    }
+    // Schema
+    if (!hasProperty(constructClass, "schema") || typeof constructClass.schema !== "object") {
+        throw new ServerlessError(
+            `The construct '${constructClass.type}' does not expose a static 'schema' property. ` +
+                "All constructs must expose a JSON schema via a 'schema' property.",
+            "LIFT_CONSTRUCT_MISSING_SCHEMA"
+        );
+    }
+}
+
+/**
+ * This crazy function only exists to make TypeScript happy with type narrowing
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+function hasProperty<X extends {}, Y extends PropertyKey>(obj: X, prop: Y): obj is X & Record<Y, unknown> {
+    // eslint-disable-next-line no-prototype-builtins
+    return obj.hasOwnProperty(prop);
+}

--- a/test/fixtures/customConstruct/construct.js
+++ b/test/fixtures/customConstruct/construct.js
@@ -1,0 +1,36 @@
+const sqs = require('@aws-cdk/aws-sqs');
+const cdk = require('@aws-cdk/core');
+
+class CustomConstruct extends cdk.Construct {
+    static schema = {
+        type: "object",
+        properties: {
+            retention: { type: "number" },
+        },
+        additionalProperties: false,
+        required: [],
+    };
+
+    static create(provider, id, configuration) {
+        return new this(provider.stack, id, configuration, provider);
+    }
+
+    constructor(app, id, configuration, provider) {
+        super(app, id);
+
+        new sqs.Queue(this, "Queue", {
+            queueName: `${provider.stackName}-${id}`,
+            retentionPeriod: cdk.Duration.days(configuration.retention),
+        });
+    }
+
+    outputs() {
+        return {};
+    }
+
+    references() {
+        return {};
+    }
+}
+
+module.exports = CustomConstruct

--- a/test/fixtures/customConstruct/construct.js
+++ b/test/fixtures/customConstruct/construct.js
@@ -2,15 +2,6 @@ const sqs = require('@aws-cdk/aws-sqs');
 const cdk = require('@aws-cdk/core');
 
 class CustomConstruct extends cdk.Construct {
-    static schema = {
-        type: "object",
-        properties: {
-            retention: { type: "number" },
-        },
-        additionalProperties: false,
-        required: [],
-    };
-
     static create(provider, id, configuration) {
         return new this(provider.stack, id, configuration, provider);
     }
@@ -32,5 +23,15 @@ class CustomConstruct extends cdk.Construct {
         return {};
     }
 }
+
+// Static property defined separately for compatibility with Node 10
+CustomConstruct.schema = {
+    type: "object",
+    properties: {
+        retention: { type: "number" },
+    },
+    additionalProperties: false,
+    required: [],
+};
 
 module.exports = CustomConstruct

--- a/test/fixtures/customConstruct/serverless.yml
+++ b/test/fixtures/customConstruct/serverless.yml
@@ -1,0 +1,13 @@
+service: custom
+configValidationMode: error
+
+provider:
+    name: aws
+
+constructs:
+    foo:
+        type: ./construct
+        retention: 4
+
+plugins:
+    - ../../../dist/src/plugin.js

--- a/test/unit/customConstruct.test.ts
+++ b/test/unit/customConstruct.test.ts
@@ -1,0 +1,24 @@
+import { runServerlessCli } from "../utils/runServerlessCli";
+
+describe("custom constructs", () => {
+    it("should be able to define AWS resources", async () => {
+        const { cfTemplate } = await runServerlessCli({
+            fixture: "customConstruct",
+            command: "package",
+        });
+        expect(Object.keys(cfTemplate.Resources)).toStrictEqual([
+            "ServerlessDeploymentBucket",
+            "ServerlessDeploymentBucketPolicy",
+            "fooQueue8CBBB428",
+        ]);
+        expect(cfTemplate.Resources.fooQueue8CBBB428).toStrictEqual({
+            Type: "AWS::SQS::Queue",
+            UpdateReplacePolicy: "Delete",
+            DeletionPolicy: "Delete",
+            Properties: {
+                QueueName: "custom-dev-foo",
+                MessageRetentionPeriod: 345600,
+            },
+        });
+    });
+});

--- a/test/utils/runServerlessCli.ts
+++ b/test/utils/runServerlessCli.ts
@@ -17,7 +17,12 @@ export async function runServerlessCli({ command, fixture }: RunServerlessCliOpt
         process.on("close", (err) => {
             if (err === 0) {
                 const json = readFileSync(
-                    __dirname + "/../fixtures/variables/.serverless/cloudformation-template-update-stack.json"
+                    path.join(
+                        __dirname,
+                        "../fixtures",
+                        fixture,
+                        ".serverless/cloudformation-template-update-stack.json"
+                    )
                 );
                 resolve({
                     stdoutData: output,


### PR DESCRIPTION
This PR replaces #23

This PR is based on #50 (the diff is more complex than it actually is)

**Note: this is a Request For Comments, not meant to be merged right now.**

Instead of creating a Lift construct that allows importing any CDK construct, this PR brings support for 3rd party **Lift constructs**.

This allows developers to use any CDK construct, **but also to add Lift features**, like:

- construct outputs
- construct variables
- automatic IAM permissions
- custom commands
- etc.

## Example

```yaml
service: app

provider:
    name: aws

constructs:
    cron:
        type: ./construct
        # any custom option

plugins:
    - serverless-lift
```

☝️  you may notice that the construct type points to the JavaScript file that contains the Lift construct. That's how discovery happens.

Example of a construct file (`construct.js`):

```js
const events = require('@aws-cdk/aws-events');
const targets = require('@aws-cdk/aws-events-targets');
const lambda = require('@aws-cdk/aws-lambda');
const cdk = require('@aws-cdk/core');

const fs = require('fs');

class Cron extends cdk.Construct {
    // JSON schema to validate the construct's configuration in serverless.yml
    static schema = {
        type: "object",
        properties: {
            timeout: { type: "number" },
        },
        additionalProperties: false,
        required: [],
    };

    static create(provider, id, configuration) {
        return new this(provider.stack, id, configuration);
    }

    constructor(app, id, configuration) {
        super(app, id);

        const lambdaFn = new lambda.Function(this, 'Handler', {
            code: new lambda.InlineCode(fs.readFileSync('lambda-handler.py', { encoding: 'utf-8' })),
            handler: 'index.main',
            timeout: cdk.Duration.seconds(3),
            runtime: lambda.Runtime.PYTHON_3_6,
        });

        const rule = new events.Rule(this, 'Rule', {
            schedule: events.Schedule.expression('rate(5 minutes)')
        });

        rule.addTarget(new targets.LambdaFunction(lambdaFn));
    }
}

module.exports = Cron
```

A construct can take advantage of Lift features, for example exposing CLI outputs:

```js
class Cron extends cdk.Construct {
    constructor(app, id, configuration, provider) {
        # ...

        this.provider = provider;

        this.functionNameOutput = new CfnOutput(this, "HandlerFunctionName", {
            value: lambdaFn.functionName,
        });
    }

    /**
     * CLI outputs
     */
    outputs() {
        return {
            functionName: () => this.provider.getStackOutput(this.functionNameOutput),
        };
    }
}

module.exports = Cron
```

Lift constructs written in TypeScript should implement the `ConstructInterface` and `StaticConstructInterface`: https://github.com/getlift/lift/blob/9977a8ac7c447953c403fea74e4ce51cbf7cb4a2/src/classes/Construct.ts#L8-L43

In order to ease implementing constructs, we may also consider making most fields optional (e.g. defining a JSON schema, etc.). Most of them are already anyway.