### PR TITLE
Add npm prepare script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,5 @@ jobs:
                     path: ~/.npm
                     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
             -   run: npm ci
-            -   run: npm run build
             -   run: npm run lint
             -   run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
             -   run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
             -   run: npm ci
             -   run: npm version $RELEASE_VERSION --no-git-tag-version
-            -   run: npm run build
             -   run: npm publish --access public
                 env:
                     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "type": "tsc --noEmit",
     "build": "etsc",
     "watch": "nodemon",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "etsc"
   },
   "types": "lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "build": "etsc",
     "watch": "nodemon",
     "test": "jest",
-    "prepare": "etsc"
+    "prepare": "npm run build"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
This is PR adds a `prepare` script to the package.json.

This is a special npm script that is executed when installing a package from a git URL like so

```bash
npm install git@github.com:t-richard/lift.git#add-prepare-script
```

This would come in handy for the community to test WIP/draft constructs and is much more user-friendly than using `npm link`.

Previously, doing this would not work because we would be missing the `dist` folder in ` node_modules/serverless-lift`

The script behaviour is described at https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts

It also says
> Runs BEFORE the package is published

This is why I also deleted `npm run build` from the release GH Action workflow
