### PR TITLE
fix addFunction to support arrays

### DIFF
--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -72,9 +72,13 @@ export class AwsProvider {
             this.serverless.configurationInput.functions = {};
         }
 
-        Object.assign(this.serverless.configurationInput.functions, {
-            [functionName]: functionConfig,
-        });
+        if (Array.isArray(this.serverless.configurationInput.functions)) {
+            this.serverless.configurationInput.functions.push({ [functionName]: functionConfig });
+        } else {
+            Object.assign(this.serverless.configurationInput.functions, {
+                [functionName]: functionConfig,
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
The Serverless Framework supports passing an [array of functions](https://www.serverless.com/framework/docs/providers/aws/guide/functions/).

When `addFunction` is called, it assumes it is an object. As a result, the function is not added to the CloudFormation template.