### PR TITLE
Simplify variables by using CDK values directly

### DIFF
--- a/src/classes/AwsConstruct.ts
+++ b/src/classes/AwsConstruct.ts
@@ -24,10 +24,5 @@ export abstract class AwsConstruct extends CdkConstruct implements ConstructInte
         return new this(provider.stack, id, configuration, provider);
     }
 
-    abstract outputs(): Record<string, () => Promise<string | undefined>>;
-
-    /**
-     * CloudFormation references
-     */
-    abstract references(): Record<string, Record<string, unknown>>;
+    abstract outputs?(): Record<string, () => Promise<string | undefined>>;
 }

--- a/src/classes/AwsProvider.ts
+++ b/src/classes/AwsProvider.ts
@@ -92,13 +92,6 @@ export class AwsProvider {
     }
 
     /**
-     * Returns a CloudFormation intrinsic function, like Fn::Ref, GetAtt, etc.
-     */
-    getCloudFormationReference(value: string): Record<string, unknown> {
-        return Stack.of(this.stack).resolve(value) as Record<string, unknown>;
-    }
-
-    /**
      * Send a request to the AWS API.
      */
     request<Input, Output>(service: string, method: string, params: Input): Promise<Output> {

--- a/src/classes/Construct.ts
+++ b/src/classes/Construct.ts
@@ -6,12 +6,15 @@ import { CliOptions } from "../types/serverless";
  * Defines which methods a Lift construct must expose.
  */
 export interface ConstructInterface {
-    outputs(): Record<string, () => Promise<string | undefined>>;
+    /**
+     * Values shown in the CLI output.
+     */
+    outputs?(): Record<string, () => Promise<string | undefined>>;
 
     /**
-     * CloudFormation references
+     * serverless.yml variables
      */
-    references(): Record<string, Record<string, unknown>>;
+    variables?(): Record<string, unknown>;
 
     /**
      * Post-CloudFormation deployment

--- a/src/constructs/Queue.ts
+++ b/src/constructs/Queue.ts
@@ -188,15 +188,15 @@ export class Queue extends AwsConstruct {
         };
     }
 
-    references(): Record<string, Record<string, unknown>> {
+    variables(): Record<string, unknown> {
         return {
-            queueUrl: this.referenceQueueUrl(),
-            queueArn: this.referenceQueueArn(),
+            queueUrl: this.queue.queueUrl,
+            queueArn: this.queue.queueArn,
         };
     }
 
     permissions(): PolicyStatement[] {
-        return [new PolicyStatement("sqs:SendMessage", [this.referenceQueueArn()])];
+        return [new PolicyStatement("sqs:SendMessage", [this.queue.queueArn])];
     }
 
     private appendFunctions(): void {
@@ -208,7 +208,7 @@ export class Queue extends AwsConstruct {
             // Subscribe the worker to the SQS queue
             {
                 sqs: {
-                    arn: this.referenceQueueArn(),
+                    arn: this.queue.queueArn,
                     batchSize: batchSize,
                     // TODO add setting
                     maximumBatchingWindow: 60,
@@ -216,14 +216,6 @@ export class Queue extends AwsConstruct {
             },
         ];
         this.provider.addFunction(`${this.id}Worker`, this.configuration.worker);
-    }
-
-    private referenceQueueArn(): Record<string, unknown> {
-        return this.provider.getCloudFormationReference(this.queue.queueArn);
-    }
-
-    private referenceQueueUrl(): Record<string, unknown> {
-        return this.provider.getCloudFormationReference(this.queue.queueUrl);
     }
 
     private async getQueueUrl(): Promise<string | undefined> {

--- a/src/constructs/StaticWebsite.ts
+++ b/src/constructs/StaticWebsite.ts
@@ -165,10 +165,6 @@ export class StaticWebsite extends AwsConstruct {
         };
     }
 
-    references(): Record<string, Record<string, unknown>> {
-        return {};
-    }
-
     async postDeploy(): Promise<void> {
         await this.uploadWebsite();
     }

--- a/src/constructs/Storage.ts
+++ b/src/constructs/Storage.ts
@@ -65,10 +65,10 @@ export class Storage extends AwsConstruct {
         });
     }
 
-    references(): Record<string, Record<string, unknown>> {
+    variables(): Record<string, unknown> {
         return {
-            bucketArn: this.referenceBucketArn(),
-            bucketName: this.referenceBucketName(),
+            bucketArn: this.bucket.bucketArn,
+            bucketName: this.bucket.bucketName,
         };
     }
 
@@ -76,11 +76,7 @@ export class Storage extends AwsConstruct {
         return [
             new PolicyStatement(
                 ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
-                [
-                    this.referenceBucketArn(),
-                    // @ts-expect-error join only accepts a list of strings, whereas other intrinsic functions are commonly accepted
-                    Stack.of(this).resolve(Fn.join("/", [this.referenceBucketArn(), "*"])),
-                ]
+                [this.bucket.bucketArn, Stack.of(this).resolve(Fn.join("/", [this.bucket.bucketArn, "*"]))]
             ),
         ];
     }
@@ -89,14 +85,6 @@ export class Storage extends AwsConstruct {
         return {
             bucketName: () => this.getBucketName(),
         };
-    }
-
-    referenceBucketName(): Record<string, unknown> {
-        return this.provider.getCloudFormationReference(this.bucket.bucketName);
-    }
-
-    referenceBucketArn(): Record<string, unknown> {
-        return this.provider.getCloudFormationReference(this.bucket.bucketArn);
     }
 
     async getBucketName(): Promise<string | undefined> {

--- a/src/constructs/Webhook.ts
+++ b/src/constructs/Webhook.ts
@@ -148,9 +148,9 @@ export class Webhook extends AwsConstruct {
         };
     }
 
-    references(): Record<string, Record<string, unknown>> {
+    variables(): Record<string, unknown> {
         return {
-            busName: this.referenceBusName(),
+            busName: this.bus.eventBusName,
         };
     }
 
@@ -188,9 +188,5 @@ export class Webhook extends AwsConstruct {
         const [, path] = endpointPath.split(" ");
 
         return apiEndpoint + path;
-    }
-
-    private referenceBusName(): Record<string, unknown> {
-        return this.provider.getCloudFormationReference(this.bus.eventBusName);
     }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -174,7 +174,7 @@ class LiftPlugin {
                     }
                     const construct = constructs[id];
 
-                    const properties = construct.references();
+                    const properties = construct.variables ? construct.variables() : {};
                     if (!has(properties, property)) {
                         if (Object.keys(properties).length === 0) {
                             throw new ServerlessError(
@@ -199,6 +199,9 @@ class LiftPlugin {
     async info(): Promise<void> {
         const constructs = this.getConstructs();
         for (const [id, construct] of Object.entries(constructs)) {
+            if (typeof construct.outputs !== "function") {
+                continue;
+            }
             const outputs = construct.outputs();
             if (Object.keys(outputs).length > 0) {
                 console.log(chalk.yellow(`${id}:`));


### PR DESCRIPTION
On `master`, construct variables are defined as CloudFormation references (or "GetAtt"). These references are generated from CDK tokens, which come from CDK object properties.

Since we already resolve all CDK tokens that appear in `serverless.yml`, we can skip some work and use the CDK variables directly.

Why:

- CDK constructs are simpler to write, and simpler to reason about
- importing existing CDK constructs as custom constructs (if we decide to merge that feature) is simplified too
- AWS variables (CF references) and non-AWS variables (i.e. if we ever support multiprovider) are unified, or at least that's the idea (we'll see in practice when we get to it)