### PR TITLE
Allow disabling automatic permissions

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,55 @@
+# IAM Permissions
+
+Lift constructs are designed to be functional out of the box.
+
+This is why some constructs automatically add permissions to the Lambda functions deployed in the same `serverless.yml` file.
+
+*Note: Lift permissions only apply to Lambda functions deployed in the same stack.*
+
+## Example
+
+For example, the `storage` construct deploys a S3 bucket and automatically allows Lambda functions to read and write into the bucket.
+
+In the example below, the IAM role for `myFunction` will automatically contain permissions to read/write the `avatars` bucket.
+
+```yaml
+# serverless.yml
+
+constructs:
+    avatars:
+        type: storage
+
+functions:
+    myFunction:
+        # ...
+```
+
+This is essentially a shortcut to setting up permissions manually like this:
+
+```yaml
+# serverless.yml
+provider:
+    iam:
+        role:
+            statements:
+                -   Effect: Allow
+                    Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"]
+                    Resource:
+                        - ${construct:avatars.bucketArn}
+                        - Fn::Join: ['', [${construct:avatars.bucketArn}, '/*']]
+
+...
+```
+
+## Disabling automatic permissions
+
+In some scenarios, you may prefer to set up IAM permissions manually.
+
+It is possible to disable Lift's automatic IAM permissions:
+
+```yaml
+# serverless.yml
+
+lift:
+    automaticPermissions: false
+```

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -146,6 +146,8 @@ functions:
             QUEUE_URL: ${construct:my-queue.queueUrl}
 ```
 
+Automatic permissions can be disabled: [read more about IAM permissions](permissions.md).
+
 ## Commands
 
 The following commands are available on `queue` constructs:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -70,6 +70,8 @@ functions:
             BUCKET_NAME: ${construct:avatars.bucketName}
 ```
 
+Automatic permissions can be disabled: [read more about IAM permissions](permissions.md).
+
 ## Configuration reference
 
 ### Encryption

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -102,4 +102,28 @@ describe("permissions", () => {
 
         expectLiftStorageStatementIsAdded(cfTemplate);
     });
+
+    it("should be possible to disable automatic permissions", async () => {
+        const { cfTemplate } = await runServerless({
+            fixture: "permissions",
+            configExt: merge({}, pluginConfigExt, {
+                // We disable automatic permissions
+                lift: {
+                    automaticPermissions: false,
+                },
+            }),
+            command: "package",
+        });
+        // There should be no "s3:*" permissions added
+        expect(
+            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
+        ).toMatchObject([
+            {
+                Action: ["logs:CreateLogStream", "logs:CreateLogGroup"],
+            },
+            {
+                Action: ["logs:PutLogEvents"],
+            },
+        ]);
+    });
 });


### PR DESCRIPTION
```yaml
# serverless.yml

lift:
    automaticPermissions: false
```

This new option allows to opt-out from automatic permissions set up by Lift constructs.