### PR TITLE
Add types definition for serverless.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ To eject:
 - copy the parts you want to turn into CloudFormation and paste them in the [`resources` section of serverless.yml](https://www.serverless.com/framework/docs/providers/aws/guide/resources/)
 - don't forget to remove from `serverless.yml` the Lift constructs you have turned into CloudFormation
 
+## [Types definition for Lift constructs](docs/serverless-types.md)
+
 ---
 
 Lift is built and maintained with love ❤️ by

--- a/docs/serverless-types.md
+++ b/docs/serverless-types.md
@@ -1,0 +1,35 @@
+# Lift Typescript definitions
+
+While YAML remains the most popular declarative syntax for Serverless service file definition - a.k.a `serverless.yml` - you can also use Javascript/Typescript definitions - i.e. `serverless.js` and `serverless.ts`. You can find more information on using JS/TS service file in the [Serverless official documentation](https://www.serverless.com/framework/docs/providers/aws/guide/intro#services).
+
+Generated Typescript types for the service file from [@serverless/typescript](https://github.com/serverless/typescript) do NOT include `constructs` definition from Lift.
+
+In order to cope this issue, Lift exports a type definition you can use in conjonction with the official Serverless definition:
+
+_serverless.ts_
+```ts
+import type { AWS } from '@serverless/typescript';
+import type { Lift } from "serverless-lift";
+
+const serverlessConfiguration: AWS & Lift = {
+  service: 'myService',
+  frameworkVersion: '2',
+  plugins: ['serverless-lift'],
+  constructs: {
+    avatars: {
+      type: 'storage',
+    },
+  },
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs14.x',
+  },
+  functions: {
+      hello: {
+          handler: 'src/publisher.handler',
+      }
+  }
+};
+
+module.exports = serverlessConfiguration;
+```

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "eslint .",
     "check-format": "prettier --check .",
     "type": "tsc --noEmit",
-    "build": "etsc",
+    "build": "etsc && tsc --emitDeclarationOnly",
     "watch": "nodemon",
     "test": "jest",
     "prepare": "husky install && npm run build"
@@ -87,7 +87,7 @@
       "eslint --fix"
     ]
   },
-  "types": "lib/index.d.ts",
+  "types": "dist/src/plugin.d.ts",
   "peerDependencies": {
     "serverless": "^2.36.0"
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import { readFileSync } from "fs";
 import { dump } from "js-yaml";
 import { DefaultTokenResolver, Lazy, StringConcat, Tokenization } from "@aws-cdk/core";
+import { FromSchema } from "json-schema-to-ts";
 import type {
     CommandsDefinition,
     DeprecatedVariableResolver,
@@ -30,11 +31,11 @@ const CONSTRUCTS_DEFINITION = {
                     },
                     required: ["type"],
                 },
-            ] as Record<string, unknown>[],
+            ],
         },
     },
     additionalProperties: false,
-};
+} as const;
 
 /**
  * Serverless plugin
@@ -97,7 +98,7 @@ class LiftPlugin {
     }
 
     private registerConstructsSchema() {
-        this.schema.patternProperties[CONSTRUCT_ID_PATTERN].allOf.push({
+        (this.schema.patternProperties[CONSTRUCT_ID_PATTERN].allOf as unknown as Record<string, unknown>[]).push({
             oneOf: this.getAllConstructClasses().map((Construct) => {
                 return this.defineConstructSchema(Construct.type, Construct.schema);
             }),
@@ -348,5 +349,9 @@ class LiftPlugin {
         return undefined;
     }
 }
+
+export type Lift = {
+    constructs: FromSchema<typeof CONSTRUCTS_DEFINITION>;
+};
 
 module.exports = LiftPlugin;


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->

# Lift Typescript definitions

While YAML remains the most popular declarative syntax for Serverless service file definition - a.k.a `serverless.yml` - you can also use Javascript/Typescript definitions - i.e. `serverless.js` and `serverless.ts`. You can find more information on using JS/TS service file in the [Serverless official documentation](https://www.serverless.com/framework/docs/providers/aws/guide/intro#services).

Generated Typescript types for the service file from [@serverless/typescript](https://github.com/serverless/typescript) do NOT include `constructs` definition from Lift.

In order to cope this issue, Lift exports a type definition you can use in conjonction with the official Serverless definition:

_serverless.ts_
```ts
import type { AWS } from '@serverless/typescript';
import type { Lift } from "serverless-lift";

const serverlessConfiguration: AWS & Lift = {
  service: 'myService',
  frameworkVersion: '2',
  plugins: ['serverless-lift'],
  constructs: {
    avatars: {
      type: 'storage',
      gsiQuantity: 2
    },
  },
  provider: {
    name: 'aws',
    runtime: 'nodejs14.x',
  },
  functions: {
      hello: {
          handler: 'src/publisher.handler',
      }
  }
};

module.exports = serverlessConfiguration;
```