### PR TITLE
Add cname variable for static-website construct

### DIFF
--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -101,6 +101,35 @@ serverless landing:upload
 
 This command only takes seconds: it directly uploads files to S3 and clears the CloudFront cache.
 
+## Variables
+
+All static-website constructs expose the following variables:
+
+- `cname`: the domain name of the resource, such as `d111111abcdef8.cloudfront.net`
+
+This can be used to reference the bucket from Route53 configuration, for example:
+
+```yaml
+constructs:
+    landing:
+        type: static-website
+        path: public
+
+resources:
+  Resources:
+    Route53Record:
+      Type: AWS::Route53::RecordSet
+      Properties:
+        HostedZoneId: ZXXXXXXXXXXXXXXXXXXJ
+        Name: app.mydomain.
+        Type: A
+        AliasTarget:
+          HostedZoneId: ZXXXXXXXXXXXXXXXXXXJ
+          DNSName: ${construct:landing.cname}
+```
+
+_How it works: the `${construct:landing.cname}` variable will automatically be replaced with a CloudFormation reference to the CloudFront Distribution._
+
 ## Configuration reference
 
 ### Path

--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -120,11 +120,11 @@ resources:
     Route53Record:
       Type: AWS::Route53::RecordSet
       Properties:
-        HostedZoneId: ZXXXXXXXXXXXXXXXXXXJ
-        Name: app.mydomain.
+        HostedZoneId: ZXXXXXXXXXXXXXXXXXXJ # Your HostedZoneId
+        Name: app.mydomain
         Type: A
         AliasTarget:
-          HostedZoneId: ZXXXXXXXXXXXXXXXXXXJ
+          HostedZoneId: Z2FDTNDATAQYW2 # Cloudfront Route53 HostedZoneId. This does not change.
           DNSName: ${construct:landing.cname}
 ```
 


### PR DESCRIPTION
When provisioning Route53 records using Cloudformation, there is no way to reference distribution CNAME generated by CloudFront (even while using custom domain names).

```yml
resources:
  Resources:
    Route53Record:
      Type: AWS::Route53::RecordSet
      Properties:
        HostedZoneId: XXXXX
        Name: app.mydomain.
        Type: A
        AliasTarget:
          HostedZoneId: XXXXX
          DNSName: !GetAtt ???.DomainName
```

This PR adds the following variable on the `static-website` construct :

- `cname`: the domain name of the resource, such as `d111111abcdef8.cloudfront.net`