### PR TITLE
Improve error message for the most common user error

### DIFF
--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -17,6 +17,7 @@ import { pollMessages, retryMessages } from "./queue/sqs";
 import { sleep } from "../../utils/sleep";
 import { PolicyStatement } from "../../CloudFormation";
 import type { CliOptions } from "../../types/serverless";
+import ServerlessError from "../../utils/error";
 
 const QUEUE_DEFINITION = {
     type: "object",
@@ -108,6 +109,16 @@ export class Queue extends AwsConstruct {
         private readonly provider: AwsProvider
     ) {
         super(scope, id);
+
+        // This should be covered by the schema validation, but until it is enforced by default
+        // this is a very common error for users
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (configuration.worker === undefined) {
+            throw new ServerlessError(
+                `Invalid configuration in 'constructs.${this.id}': no 'worker' defined. Queue constructs require a 'worker' function to be defined.`,
+                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+            );
+        }
 
         // The default function timeout is 6 seconds in the Serverless Framework
         const functionTimeout = configuration.worker.timeout ?? 6;


### PR DESCRIPTION
Serverless' JSON schema validation should forbid users to define a "Queue" construct without a `worker` defined inside of it.

However, this schema validation isn't enforced strictly at the moment. This is the error users get in that case:

<img width="1125" alt="Screen 2021-09-08 14-35" src="https://user-images.githubusercontent.com/720328/132512412-b60f81fa-451d-463c-9b39-3fef626cca4c.png">

This is the most common "Lift internal error/bug" that users face (that is caused by Lift).

With this PR, users get a more explicit error:

<img width="1181" alt="Screen 2021-09-08 14-26" src="https://user-images.githubusercontent.com/720328/132512332-202fa43f-9a20-447e-a4af-a1e77a461ff9.png">

This isn't ideal, but it improves the onboarding experience.