### PR TITLE
feat: redirect to main domain in static and server-side websites

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -286,6 +286,22 @@ Usually, we can retrieve which domain a user is visiting via the `Host` HTTP hea
 
 The `server-side-website` construct offers a workaround: the `X-Forwarded-Host` header is automatically populated via CloudFront Functions. Code running on Lambda will be able to access the original `Host` header via this `X-Forwarded-Host` header.
 
+#### Redirect all domains to a single one
+
+It is sometimes necessary to redirect every request to a single domain. A common example is to redirect the root domain to the `www` version.
+
+```yaml
+constructs:
+    website:
+        # ...
+        domain:
+            - www.mywebsite.com
+            - mywebsite.com
+        redirectToMainDomain: true
+```
+
+The first domain in the list will be considered the main domain. In this case, `mywebsite.com` will redirect to `www.mywebsite.com`.
+
 ### Error pages
 
 ```yaml

--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -195,6 +195,22 @@ constructs:
             - app.mywebsite.com
 ```
 
+#### Redirect all domains to a single one
+
+It is sometimes necessary to redirect one or several domains to a single one. A common example is to redirect the root domain to the `www` version.
+
+```yaml
+constructs:
+    website:
+        # ...
+        domain:
+            - www.mywebsite.com
+            - mywebsite.com
+        redirectToMainDomain: true
+```
+
+The first domain in the list will be considered the main domain. In this case, `mywebsite.com` will redirect to `www.mywebsite.com`.
+
 ### Error page
 
 By default, all 404 requests are redirected to `index.html` with a 200 response status. This behavior is optimized for Single-Page Applications: it allows doing client-side URL routing with JavaScript frameworks.

--- a/src/classes/cloudfrontFunctions.ts
+++ b/src/classes/cloudfrontFunctions.ts
@@ -1,0 +1,25 @@
+import ServerlessError from "../utils/error";
+
+export function redirectToMainDomain(domains: string[] | undefined): string {
+    if (domains === undefined || domains.length < 2) {
+        throw new ServerlessError(
+            `Invalid value in 'redirectToMainDomain': you must have at least 2 domains configured to enable redirection to the main domain.`,
+            "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+        );
+    }
+
+    const mainDomain = domains[0];
+
+    return `
+    if (request.headers["host"].value !== "${mainDomain}") {
+        return {
+            statusCode: 301,
+            statusDescription: "Moved Permanently",
+            headers: {
+                location: {
+                    value: "https://${mainDomain}" + request.uri
+                }
+            }
+        };
+    }`;
+}


### PR DESCRIPTION
This PR implements redirection to a "main domain". This is especially useful for root domain to www redirections. 

The first domain will be used as the main domain where everything will redirect to if `redirectToMainDomain` is true. 

```yaml
constructs: 
    website: 
        type: "server-side-website"
        domain: 
            - www.example.com
            - example.com
        certificate: "arn:aws:acm:us-east-1:123456615250:certificate/0a28e63d-d3a9-4578-9f8b-14347bfe8123"
        redirectToMainDomain: true
```

This will redirect every request targeting `example.com` to `www.example.com`.

I've used Cloudfront functions to do this, it seems to be the best solution for this. There are other solutions with buckets doing redirects but this feels wrong to me now that we have Cloudfront Functions available.