### PR TITLE
React construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,21 @@ The [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/home.html) is extreme
 
 Lift provides components, aka "**constructs**", specifically selected for serverless applications. They are all built using the CDK and its best practices, with unique features to provide an awesome developer experience.
 
+### [React website](docs/react-website.md)
+
+Deploy React websites.
+
+```yaml
+constructs:
+    landing:
+        type: react-website
+```
+
+[Read more...](docs/react-website.md)
+
 ### [Static website](docs/static-website.md)
 
-Deploy static websites and single-page applications, for example React, VueJS or Angular apps.
+Deploy static websites and single-page applications, for example VueJS or Angular apps.
 
 ```yaml
 constructs:

--- a/docs/react-website.md
+++ b/docs/react-website.md
@@ -1,0 +1,126 @@
+# React website
+
+The `react-website` construct deploys React websites created with [Create React App](https://create-react-app.dev/).
+
+## Quick start
+
+```bash
+serverless plugin install -n serverless-lift
+```
+
+```yaml
+service: my-app
+provider:
+    name: aws
+
+constructs:
+    website:
+        type: react-website
+
+plugins:
+    - serverless-lift
+```
+
+On `serverless deploy`, the application will be built (via `npm run build`) and deployed as a public website.
+
+_Note: **the first deployment takes 4 minutes**. Next deployments only take seconds._
+
+The website is served over HTTPS and cached all over the world via the CloudFront CDN.
+
+## How it works
+
+The `react-website` construct is based on the [`static-website` construct: read its documentation to learn more](static-website.md#how-it-works).
+
+## Commands
+
+The following commands are available on `react-website` constructs:
+
+```
+serverless <construct-name>:upload
+serverless <construct-name>:dev
+serverless <construct-name>:build
+```
+
+- `serverless <construct-name>:upload`
+
+`serverless deploy` deploys everything configured in `serverless.yml` and uploads website files.
+
+`serverless <construct-name>:upload` skips the build and CloudFormation deployment: it directly uploads files to S3 and clears the CloudFront cache.
+
+- `serverless <construct-name>:dev`
+
+Runs the React website locally via `npm start`.
+
+- `serverless <construct-name>:build`
+
+Builds the React website locally via `npm run build`.
+
+Note: `serverless deploy` automatically builds the website before deploying.
+
+## Configuration reference
+
+### Custom domain
+
+```yaml
+constructs:
+    landing:
+        # ...
+        domain: mywebsite.com
+        # ARN of an ACM certificate for the domain, registered in us-east-1
+        certificate: arn:aws:acm:us-east-1:123456615250:certificate/0a28e63d-d3a9-4578-9f8b-14347bfe8123
+```
+
+The configuration above will activate the custom domain `mywebsite.com` on CloudFront, using the provided HTTPS certificate.
+
+After running `serverless deploy` (or `serverless info`), you should see the following output in the terminal:
+
+```
+landing:
+  url: https://mywebsite.com
+  cname: s13hocjp.cloudfront.net
+```
+
+Create a CNAME DNS entry that points your domain to the `xxx.cloudfront.net` domain. After a few minutes/hours, the domain should be available.
+
+#### HTTPS certificate
+
+To create the HTTPS certificate:
+
+- Open [the ACM Console](https://console.aws.amazon.com/acm/home?region=us-east-1#/wizard/) in the `us-east-1` region (CDN certificates _must be_ in us-east-1, regardless of where your application is hosted)
+- Click "_Request a new certificate_", add your domain name and click "Next"
+- Choose a domain validation method:
+  - Domain validation will require you to add CNAME entries to your DNS configuration
+  - Email validation will require you to click a link in an email sent to `admin@your-domain.com`
+
+After the certificate is created and validated, you should see the ARN of the certificate.
+
+#### Multiple domains
+
+It is possible to set up multiple domains:
+
+```yaml
+constructs:
+    landing:
+        # ...
+        domain:
+            - mywebsite.com
+            - app.mywebsite.com
+```
+
+### Allow iframes
+
+By default, as recommended [for security reasons](https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options), the static website cannot be embedded in an iframe.
+
+To allow embedding the website in an iframe, set it up explicitly:
+
+```yaml
+constructs:
+    landing:
+        # ...
+        security:
+            allowIframe: true
+```
+
+### More options
+
+Looking for more options in the construct configuration? [Open a GitHub issue](https://github.com/getlift/lift/issues/new).

--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -5,6 +5,8 @@ The `static-website` construct deploys:
 - **single-page applications**, for example React or VueJS applications
 - **plain static websites** composed of HTML files and assets (CSS, JS…)
 
+Note: a [`react-website` construct](react-website.md) exists specifically for React applications.
+
 ## Quick start
 
 ```bash
@@ -52,21 +54,8 @@ _Note: the S3 bucket is public and entirely managed by Lift. Do not store or upl
 
 ## React
 
-To deploy a [React](https://reactjs.org/) app, use the following configuration:
-
-```yaml
-constructs:
-    react:
-        type: static-website
-        path: build
-```
-
-To deploy, run:
-
-```
-npm run build
-serverless deploy
-```
+Deploy React applications with [the `react-website` construct](react-website.md).
+It is based on `static-website` and optimized for React applications.
 
 ## Vue
 

--- a/src/constructs/ConstructInterface.ts
+++ b/src/constructs/ConstructInterface.ts
@@ -15,6 +15,11 @@ export interface ConstructInterface {
     variables?(): Record<string, unknown>;
 
     /**
+     * Pre-CloudFormation deployment
+     */
+    preDeploy?(): Promise<void>;
+
+    /**
      * Post-CloudFormation deployment
      */
     postDeploy?(): Promise<void>;

--- a/src/constructs/StaticConstructInterface.ts
+++ b/src/constructs/StaticConstructInterface.ts
@@ -2,15 +2,17 @@ import type { ConstructInterface } from "@lift/constructs";
 import type { ProviderInterface } from "@lift/providers";
 import type { CliOptions } from "../types/serverless";
 
+export type ConstructSchema = {
+    type: "object";
+    [k: string]: unknown;
+};
+
 /**
  * Defines which static properties and methods a Lift construct must expose.
  */
 export interface StaticConstructInterface {
     type: string;
-    schema: {
-        type: "object";
-        [k: string]: unknown;
-    };
+    schema: ConstructSchema;
     commands?: ConstructCommands;
     create(provider: ProviderInterface, id: string, configuration: Record<string, unknown>): ConstructInterface;
 }

--- a/src/constructs/aws/ReactWebsite.ts
+++ b/src/constructs/aws/ReactWebsite.ts
@@ -1,0 +1,79 @@
+import type { Construct as CdkConstruct } from "@aws-cdk/core/lib/construct-compat";
+import type { FromSchema } from "json-schema-to-ts";
+import type { AwsProvider } from "@lift/providers";
+import { StaticWebsite } from "@lift/constructs/aws/index";
+import type { ConstructCommands } from "@lift/constructs/StaticConstructInterface";
+import { merge } from "lodash";
+import { spawn } from "child_process";
+import { log } from "../../utils/logger";
+
+const SCHEMA = {
+    type: "object",
+    properties: {
+        domain: {
+            anyOf: [
+                { type: "string" },
+                {
+                    type: "array",
+                    items: { type: "string" },
+                },
+            ],
+        },
+        certificate: { type: "string" },
+        security: {
+            type: "object",
+            properties: {
+                allowIframe: { type: "boolean" },
+            },
+            additionalProperties: false,
+        },
+    },
+    additionalProperties: false,
+} as const;
+
+type Configuration = FromSchema<typeof SCHEMA>;
+
+export class ReactWebsite extends StaticWebsite {
+    public static type = "react-website";
+    public static schema = SCHEMA;
+    public static commands: ConstructCommands = merge(StaticWebsite.commands, {
+        build: {
+            usage: "Build the website with 'npm run build'.",
+            handler: ReactWebsite.prototype.build,
+        },
+        dev: {
+            usage: "Run the website locally with 'npm start'.",
+            handler: ReactWebsite.prototype.dev,
+        },
+    });
+
+    constructor(scope: CdkConstruct, id: string, configuration: Configuration, provider: AwsProvider) {
+        const websiteConfiguration = Object.assign(
+            {},
+            {
+                path: "build",
+            },
+            configuration
+        );
+
+        super(scope, id, websiteConfiguration, provider);
+    }
+
+    preDeploy(): void {
+        this.build();
+    }
+
+    build(): void {
+        log(`Building '${this.id}' with 'npm run build'`);
+        spawn("npm", ["run", "build"], {
+            stdio: "inherit",
+        });
+    }
+
+    dev(): void {
+        log(`Running 'npm start'`);
+        spawn("npm", ["start"], {
+            stdio: "inherit",
+        });
+    }
+}

--- a/src/constructs/aws/StaticWebsite.ts
+++ b/src/constructs/aws/StaticWebsite.ts
@@ -20,16 +20,16 @@ import type { ErrorResponse } from "@aws-cdk/aws-cloudfront/lib/distribution";
 import type { AwsProvider } from "@lift/providers";
 import { AwsConstruct } from "@lift/constructs/abstracts";
 import type { ConstructCommands } from "@lift/constructs";
+import type { ConstructSchema } from "@lift/constructs/StaticConstructInterface";
 import { log } from "../../utils/logger";
 import { s3Sync } from "../../utils/s3-sync";
 import ServerlessError from "../../utils/error";
 import { emptyBucket, invalidateCloudFrontCache } from "../../classes/aws";
 import { redirectToMainDomain } from "../../classes/cloudfrontFunctions";
 
-const STATIC_WEBSITE_DEFINITION = {
+export const STATIC_WEBSITE_DEFINITION = {
     type: "object",
     properties: {
-        type: { const: "static-website" },
         path: { type: "string" },
         domain: {
             anyOf: [
@@ -55,11 +55,11 @@ const STATIC_WEBSITE_DEFINITION = {
     required: ["path"],
 } as const;
 
-type Configuration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;
+export type StaticWebsiteConfiguration = FromSchema<typeof STATIC_WEBSITE_DEFINITION>;
 
 export class StaticWebsite extends AwsConstruct {
     public static type = "static-website";
-    public static schema = STATIC_WEBSITE_DEFINITION;
+    public static schema: ConstructSchema = STATIC_WEBSITE_DEFINITION;
     public static commands: ConstructCommands = {
         upload: {
             usage: "Upload files directly to S3 without going through a CloudFormation deployment.",
@@ -76,9 +76,9 @@ export class StaticWebsite extends AwsConstruct {
 
     constructor(
         scope: CdkConstruct,
-        private readonly id: string,
-        private readonly configuration: Configuration,
-        private readonly provider: AwsProvider
+        protected readonly id: string,
+        protected readonly configuration: StaticWebsiteConfiguration,
+        protected readonly provider: AwsProvider
     ) {
         super(scope, id);
 

--- a/src/constructs/aws/index.ts
+++ b/src/constructs/aws/index.ts
@@ -5,3 +5,4 @@ export { Storage } from "./Storage";
 export { Vpc } from "./Vpc";
 export { Webhook } from "./Webhook";
 export { ServerSideWebsite } from "./ServerSideWebsite";
+export { ReactWebsite } from "./ReactWebsite";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -108,6 +108,7 @@ class LiftPlugin {
             },
             "before:aws:info:displayStackOutputs": this.info.bind(this),
             "after:package:compileEvents": this.appendCloudformationResources.bind(this),
+            "before:deploy:deploy": this.preDeploy.bind(this),
             "after:deploy:deploy": this.postDeploy.bind(this),
             "before:remove:remove": this.preRemove.bind(this),
             "lift:eject:eject": this.eject.bind(this),
@@ -359,6 +360,15 @@ class LiftPlugin {
 
                     return commandDefinition.handler.call(construct, this.cliOptions);
                 };
+            }
+        }
+    }
+
+    private async preDeploy(): Promise<void> {
+        const constructs = this.getConstructs();
+        for (const [, construct] of Object.entries(constructs)) {
+            if (construct.preDeploy !== undefined) {
+                await construct.preDeploy();
             }
         }
     }

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -7,6 +7,7 @@ import type { ConstructInterface, StaticConstructInterface } from "@lift/constru
 import {
     DatabaseDynamoDBSingleTable,
     Queue,
+    ReactWebsite,
     ServerSideWebsite,
     StaticWebsite,
     Storage,
@@ -172,5 +173,6 @@ AwsProvider.registerConstructs(
     StaticWebsite,
     Vpc,
     DatabaseDynamoDBSingleTable,
-    ServerSideWebsite
+    ServerSideWebsite,
+    ReactWebsite
 );

--- a/test/unit/react.test.ts
+++ b/test/unit/react.test.ts
@@ -1,0 +1,307 @@
+import * as sinon from "sinon";
+import { baseConfig, runServerless } from "../utils/runServerless";
+
+describe("react", () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("should create all required resources", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "react-website",
+                    },
+                },
+            }),
+        });
+        const bucketLogicalId = computeLogicalId("landing", "Bucket");
+        const bucketPolicyLogicalId = computeLogicalId("landing", "Bucket", "Policy");
+        const originAccessIdentityLogicalId = computeLogicalId("landing", "OriginAccessIdentity");
+        const requestFunction = computeLogicalId("landing", "RequestFunction");
+        const responseFunction = computeLogicalId("landing", "ResponseFunction");
+        const cfDistributionLogicalId = computeLogicalId("landing", "CDN");
+        const cfOriginId = computeLogicalId("landing", "CDN", "Origin1");
+        expect(Object.keys(cfTemplate.Resources)).toStrictEqual([
+            "ServerlessDeploymentBucket",
+            "ServerlessDeploymentBucketPolicy",
+            bucketLogicalId,
+            bucketPolicyLogicalId,
+            originAccessIdentityLogicalId,
+            requestFunction,
+            responseFunction,
+            cfDistributionLogicalId,
+        ]);
+        expect(cfTemplate.Resources[bucketLogicalId]).toMatchObject({
+            Type: "AWS::S3::Bucket",
+            UpdateReplacePolicy: "Delete",
+            DeletionPolicy: "Delete",
+        });
+        expect(cfTemplate.Resources[bucketPolicyLogicalId]).toMatchObject({
+            Properties: {
+                Bucket: {
+                    Ref: bucketLogicalId,
+                },
+                PolicyDocument: {
+                    Statement: [
+                        {
+                            Action: ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
+                            Effect: "Allow",
+                            Principal: {
+                                CanonicalUser: {
+                                    "Fn::GetAtt": [originAccessIdentityLogicalId, "S3CanonicalUserId"],
+                                },
+                            },
+                            Resource: [
+                                {
+                                    "Fn::GetAtt": [bucketLogicalId, "Arn"],
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Fn::GetAtt": [bucketLogicalId, "Arn"],
+                                            },
+                                            "/*",
+                                        ],
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    Version: "2012-10-17",
+                },
+            },
+        });
+        expect(cfTemplate.Resources[originAccessIdentityLogicalId]).toMatchObject({
+            Type: "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+            Properties: {
+                CloudFrontOriginAccessIdentityConfig: {
+                    Comment: "Identity that represents CloudFront for the landing static website.",
+                },
+            },
+        });
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+                DistributionConfig: {
+                    CustomErrorResponses: [
+                        {
+                            ErrorCachingMinTTL: 0,
+                            ErrorCode: 404,
+                            ResponseCode: 200,
+                            ResponsePagePath: "/index.html",
+                        },
+                    ],
+                    DefaultCacheBehavior: {
+                        AllowedMethods: ["GET", "HEAD", "OPTIONS"],
+                        Compress: true,
+                        TargetOriginId: cfOriginId,
+                        ViewerProtocolPolicy: "redirect-to-https",
+                        FunctionAssociations: [
+                            {
+                                EventType: "viewer-request",
+                                FunctionARN: {
+                                    "Fn::GetAtt": [requestFunction, "FunctionARN"],
+                                },
+                            },
+                            {
+                                EventType: "viewer-response",
+                                FunctionARN: {
+                                    "Fn::GetAtt": [responseFunction, "FunctionARN"],
+                                },
+                            },
+                        ],
+                    },
+                    DefaultRootObject: "index.html",
+                    Enabled: true,
+                    HttpVersion: "http2",
+                    IPV6Enabled: true,
+                    Origins: [
+                        {
+                            DomainName: {
+                                "Fn::GetAtt": [bucketLogicalId, "RegionalDomainName"],
+                            },
+                            Id: cfOriginId,
+                            S3OriginConfig: {
+                                OriginAccessIdentity: {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "origin-access-identity/cloudfront/",
+                                            {
+                                                Ref: originAccessIdentityLogicalId,
+                                            },
+                                        ],
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+        expect(cfTemplate.Outputs).toMatchObject({
+            [computeLogicalId("landing", "BucketName")]: {
+                Description: "Name of the bucket that stores the static website.",
+                Value: {
+                    Ref: bucketLogicalId,
+                },
+            },
+            [computeLogicalId("landing", "Domain")]: {
+                Description: "Website domain name.",
+                Value: {
+                    "Fn::GetAtt": [cfDistributionLogicalId, "DomainName"],
+                },
+            },
+            [computeLogicalId("landing", "CloudFrontCName")]: {
+                Description: "CloudFront CNAME.",
+                Value: {
+                    "Fn::GetAtt": [cfDistributionLogicalId, "DomainName"],
+                },
+            },
+            [computeLogicalId("landing", "DistributionId")]: {
+                Description: "ID of the CloudFront distribution.",
+                Value: {
+                    Ref: cfDistributionLogicalId,
+                },
+            },
+        });
+        expect(cfTemplate.Resources[responseFunction]).toMatchObject({
+            Type: "AWS::CloudFront::Function",
+            Properties: {
+                AutoPublish: true,
+                FunctionConfig: {
+                    Comment: "app-dev-us-east-1-landing-response",
+                    Runtime: "cloudfront-js-1.0",
+                },
+                Name: "app-dev-us-east-1-landing-response",
+            },
+        });
+    });
+
+    it("should support a custom domain", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "react-website",
+                        domain: "example.com",
+                        certificate:
+                            "arn:aws:acm:us-east-1:123456615250:certificate/0a28e63d-d3a9-4578-9f8b-14347bfe8123",
+                    },
+                },
+            }),
+        });
+        const cfDistributionLogicalId = computeLogicalId("landing", "CDN");
+        // Check that CloudFront uses the custom ACM certificate and custom domain
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+                DistributionConfig: {
+                    Aliases: ["example.com"],
+                    ViewerCertificate: {
+                        AcmCertificateArn:
+                            "arn:aws:acm:us-east-1:123456615250:certificate/0a28e63d-d3a9-4578-9f8b-14347bfe8123",
+                        MinimumProtocolVersion: "TLSv1.2_2019",
+                        SslSupportMethod: "sni-only",
+                    },
+                },
+            },
+        });
+        // The domain should be the custom domain, not the CloudFront one
+        expect(cfTemplate.Outputs).toMatchObject({
+            [computeLogicalId("landing", "Domain")]: {
+                Description: "Website domain name.",
+                Value: "example.com",
+            },
+            [computeLogicalId("landing", "CloudFrontCName")]: {
+                Description: "CloudFront CNAME.",
+                Value: {
+                    "Fn::GetAtt": [cfDistributionLogicalId, "DomainName"],
+                },
+            },
+        });
+    });
+
+    it("should support multiple custom domains", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "react-website",
+                        domain: ["example.com", "www.example.com"],
+                        certificate:
+                            "arn:aws:acm:us-east-1:123456615250:certificate/0a28e63d-d3a9-4578-9f8b-14347bfe8123",
+                    },
+                },
+            }),
+        });
+        const cfDistributionLogicalId = computeLogicalId("landing", "CDN");
+        // Check that CloudFront uses all the custom domains
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+                DistributionConfig: {
+                    Aliases: ["example.com", "www.example.com"],
+                },
+            },
+        });
+        // This should contain the first domain of the list
+        expect(cfTemplate.Outputs).toMatchObject({
+            [computeLogicalId("landing", "Domain")]: {
+                Description: "Website domain name.",
+                Value: "example.com",
+            },
+            [computeLogicalId("landing", "CloudFrontCName")]: {
+                Description: "CloudFront CNAME.",
+                Value: {
+                    "Fn::GetAtt": [cfDistributionLogicalId, "DomainName"],
+                },
+            },
+        });
+    });
+
+    it("should allow to customize security HTTP headers", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "react-website",
+                        security: {
+                            allowIframe: true,
+                        },
+                    },
+                },
+            }),
+        });
+        const edgeFunction = computeLogicalId("landing", "ResponseFunction");
+        expect(cfTemplate.Resources[edgeFunction]).toMatchObject({
+            Type: "AWS::CloudFront::Function",
+            Properties: {
+                // Check that the `x-frame-options` header is not set
+                FunctionCode: `function handler(event) {
+    var response = event.response;
+    response.headers = Object.assign({}, {
+    "x-content-type-options": {
+        "value": "nosniff"
+    },
+    "x-xss-protection": {
+        "value": "1; mode=block"
+    },
+    "strict-transport-security": {
+        "value": "max-age=63072000"
+    }
+}, response.headers);
+    return response;
+}`,
+            },
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a `react` website construct.

This construct is heavily based on the `static-website` construct.

Why a separate React construct? Yes, it is possible to deploy a React application with the existing [static website construct](https://github.com/getlift/lift/blob/master/docs/static-website.md). That new construct is preconfigured specifically for React. It is slightly more practical.

The difference will not especially be in technical terms. It is an attempt at being even closer to the real use cases of developers. In terms of adoption, we also want to see if we can get more attention from the React community by adapting serverless to _their_ world, instead of adapting React to the serverless world.

**In other words, starting from users and communities instead of starting from the technical solution.**

Example:

```yaml
service: my-app
provider:
    name: aws

constructs:
    website:
        type: react-website

plugins:
    - serverless-lift
```

On `serverless deploy`, the application will be built (via `npm run build`) and deployed as a public website.

[Full documentation](https://github.com/getlift/lift/blob/react/docs/react-website.md)

---

On a side note, this was an interesting first step into construct reuse (which could be big with #23).