### PR TITLE
#99 Support Docker images for queue handlers

### DIFF
--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -26,10 +26,8 @@ const QUEUE_DEFINITION = {
         worker: {
             type: "object",
             properties: {
-                handler: { type: "string" },
                 timeout: { type: "number" },
             },
-            required: ["handler"],
             additionalProperties: true,
         },
         maxRetries: { type: "number" },


### PR DESCRIPTION
Fix #99 

This allows to use Docker images in SQS function handlers, for example:

```yaml
provider:
  name: aws
  ecr:
    images:
      my-docker-image:
        path: ./

constructs:
  my-queue:
    type: queue
    worker:
      image:
        name: my-docker-image
```
