### PR TITLE
[static-website] fix: stop silent fail on s3 deleteObjects

### DIFF
--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -605,7 +605,13 @@ describe("server-side website", () => {
             ],
         });
         const putObjectSpy = awsMock.mockService("S3", "putObject");
-        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects");
+        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects").resolves({
+            Deleted: [
+                {
+                    Key: "assets/image.jpg",
+                },
+            ],
+        });
         const cloudfrontInvalidationSpy = awsMock.mockService("CloudFront", "createInvalidation");
 
         await runServerless({

--- a/test/unit/staticWebsites.test.ts
+++ b/test/unit/staticWebsites.test.ts
@@ -445,7 +445,13 @@ describe("static websites", () => {
             ],
         });
         const putObjectSpy = awsMock.mockService("S3", "putObject");
-        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects");
+        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects").resolves({
+            Deleted: [
+                {
+                    Key: "image.jpg",
+                },
+            ],
+        });
         const cloudfrontInvalidationSpy = awsMock.mockService("CloudFront", "createInvalidation");
 
         await runServerless({


### PR DESCRIPTION
Hello and thanks a lot for this awesome project!

When using the `static-website` construct on my project, I realized that I had forgotten the `s3:deleteObject` IAM permission of my deployment policy. Therefore, the s3 files synced with lift were never deleted. However, no error was thrown and the deployement failed silently.

This silent fail is due to a particularity in the S3 `deleteObjects` [SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObjects-property) and the [corresponding HTTP API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html). Since this API can encounter partial failures, the call never fails but returns the errors in a `Errors` key.

I think that Lift should explicitely fail when the `Errors` key is defined and the list of errors is not empty. In this case, the proposed error is the following:

```
Deleting index.html
{
  Key: 'index.html',
  Code: 'AccessDenied',
  Message: 'Access Denied'
}
 
 Serverless Error ----------------------------------------
 
  Unable to delete files
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          linux
     Node Version:              14.16.1
     Framework Version:         2.61.0 (local)
     Plugin Version:            5.4.5
     SDK Version:               4.3.0
     Components Version:        3.17.1
 
```