### PR TITLE
Fix documentation to make it work out of the box

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -36,7 +36,7 @@ provider:
                     Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"]
                     Resource:
                         - ${construct:avatars.bucketArn}
-                        - Fn::Join: ['', [${construct:avatars.bucketArn}, '/*']]
+                        - Fn::Join: ['', ['${construct:avatars.bucketArn}', '/*']]
 
 ...
 ```


### PR DESCRIPTION
The documentation example was throwing this error:

```
Cannot parse "serverless.yaml": missed comma between flow collection entries in "/Users/flavianhautbois/apricity/apricity-cdr/cdr-orchestrators/serverless.yaml" (36:48)
  
   33 |  ...        Action: ["s3:PutObject", "s3:ListBucket"]
   34 |  ...        Resource:
   35 |  ...            - ${construct:tdl.bucketArn}
   36 |  ...            - Fn::Join: ['', [${construct:tdl.bucketArn}, '/*']]
```
