### PR TITLE
use path.posix.join() to avoid issues with OS path separators that co…

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -256,7 +256,7 @@ export class ServerSideWebsite extends AwsConstruct {
                 invalidate = invalidate || hasChanges;
             } else {
                 // File
-                const targetKey = path.join(s3PathPrefix, path.basename(filePath));
+                const targetKey = path.posix.join(s3PathPrefix, path.basename(filePath));
                 log(`Uploading '${filePath}' to 's3://${bucketName}/${targetKey}'`);
                 await s3Put(this.provider, bucketName, targetKey, fs.readFileSync(filePath));
                 invalidate = true;

--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -47,8 +47,8 @@ export async function s3Sync({
     for (const batch of chunk(filesToUpload, 2)) {
         await Promise.all(
             batch.map(async (file) => {
-                const targetKey = targetPathPrefix !== undefined ? path.join(targetPathPrefix, file) : file;
-                const fileContent = fs.readFileSync(path.join(localPath, file));
+                const targetKey = targetPathPrefix !== undefined ? path.posix.join(targetPathPrefix, file) : file;
+                const fileContent = fs.readFileSync(path.posix.join(localPath, file));
 
                 // Check that the file isn't already uploaded
                 if (targetKey in existingS3Objects) {
@@ -72,7 +72,7 @@ export async function s3Sync({
     }
 
     const targetKeys = filesToUpload.map((file) =>
-        targetPathPrefix !== undefined ? path.join(targetPathPrefix, file) : file
+        targetPathPrefix !== undefined ? path.posix.join(targetPathPrefix, file) : file
     );
     const keysToDelete = findKeysToDelete(Object.keys(existingS3Objects), targetKeys);
     if (keysToDelete.length > 0) {
@@ -89,14 +89,14 @@ async function listFilesRecursively(directory: string): Promise<string[]> {
 
     const files = await Promise.all(
         items.map(async (fileName) => {
-            const fullPath = path.join(directory, fileName);
+            const fullPath = path.posix.join(directory, fileName);
             const fileStat = await stat(fullPath);
             if (fileStat.isFile()) {
                 return [fileName];
             } else if (fileStat.isDirectory()) {
                 const subFiles = await listFilesRecursively(fullPath);
 
-                return subFiles.map((subFileName) => path.join(fileName, subFileName));
+                return subFiles.map((subFileName) => path.posix.join(fileName, subFileName));
             }
 
             return [];


### PR DESCRIPTION
On the Windows platform using Cygwin64, path.join() appears to use the Windows path separator ('\') instead of the POSIX path separator which causes files in directories uploaded to AWS S3 to contain a backslash and become inaccessible.  path.posix.join() appears to use the correct path separator for AWS S3.

Example of issue 
---
serverless.yml config:
```
    assets:
      '/js/*': assets/js
```
`aws s3 ls <bucket>` listing:
```
2021-11-18 15:29:18      50205 js\analytics.js
2021-11-18 15:29:18       8233 js\bootstrap-datepicker.min.js
2021-11-18 15:29:19      36399 js\bootstrap.min.js
```
After code changes, `aws s3 ls <bucket>`:
```
                           PRE js/
```
And `aws s3 ls <bucket>/js/`:
```
2021-11-18 20:57:23      50205 analytics.js
2021-11-18 20:57:23       8233 bootstrap-datepicker.min.js
2021-11-18 20:57:23      36399 bootstrap.min.js
```

hth, use as needed
