### PR TITLE
Issue templates forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,11 +3,6 @@ description: Report a bug in Lift
 labels: bug
 
 body:
-    - type: input
-      id: construct
-      attributes:
-          label: Affected Construct
-          placeholder: If applicable (eg. queue, storage)
     - type: textarea
       id: description
       attributes:
@@ -23,12 +18,9 @@ body:
       validations:
           required: true
     - type: textarea
-      id: possible-solution
-      attributes:
-          label: Possible Solution
-          description: "Optional: only if you have suggestions on a fix for the bug"
-    - type: textarea
       id: additional-information
       attributes:
           label: Additional Information
-          description: "Optional: any other details about the problem: screenshot, affected Lift version, Serverless Framework version,etc"
+          description: |
+              Optional: any other details that may help.
+              Possible solution, screenshot, affected Lift version, Serverless Framework version, etc.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,34 @@
+name: 🐛 Bug report
+description: Report a bug in Lift
+labels: bug
+
+body:
+    - type: input
+      id: construct
+      attributes:
+          label: Affected Construct
+          placeholder: If applicable (eg. queue, storage)
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of what the bug is, with the complete error message when relevant.
+      validations:
+          required: true
+    - type: textarea
+      id: how-to-reproduce
+      attributes:
+          label: How to Reproduce
+          description: "`serverless.yml` configuration and other information needed to reproduce the issue."
+      validations:
+          required: true
+    - type: textarea
+      id: possible-solution
+      attributes:
+          label: Possible Solution
+          description: "Optional: only if you have suggestions on a fix for the bug"
+    - type: textarea
+      id: additional-information
+      attributes:
+          label: Additional Information
+          description: "Optional: any other details about the problem: screenshot, affected Lift version, Serverless Framework version,etc"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: 🙌 Community support
+      url: https://github.com/getlift/lift/discussions
+      about: Please ask and answer questions in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,24 @@
+name: ✨ New Construct, Feature or Improvement
+description: Suggest something new
+labels: enhancement
+
+body:
+    - type: textarea
+      id: use-case
+      attributes:
+          label: Start from the Use-case
+          description: Describe the problem you're trying to solve, rather than the technical solution you may have.
+      validations:
+          required: true
+    - type: textarea
+      id: example-config
+      attributes:
+          label: Example Config
+          description: "Optional: An example of the Construct config when applicable."
+    - type: textarea
+      id: implementation-idea
+      attributes:
+          label: Implementation Idea
+          description: |
+              Optional: Describe here how this might be solved from a technical point-of-view.
+              Cloudformation property, required resources, output or variable needed, etc.


### PR DESCRIPTION
I noticed we tend to regularly ask people the same information when they create an issue, especially when requesting a new feature (what is the use-case, what config could look like, etc).

This PR introduces issue templates **forms**

This is a recent Github feature that creates an actual form which users have to fill. 

I tried to make it simple enough so that is doesn't discourages people from submitting but still give a bit more structure.

You can see a preview on my fork, feel free to create an issue there to see how it looks https://github.com/t-richard/lift/issues/new/choose

