### PR TITLE
Mark plugin as compatible with v3 of `serverless`

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
   },
   "types": "dist/src/plugin.d.ts",
   "peerDependencies": {
-    "serverless": "^2.36.0"
+    "serverless": "^2.36.0 || 3"
   }
 }


### PR DESCRIPTION
It's needed so users can upgrade to v3 of the Framework without issues