### PR TITLE
Add Server-Side encryption option for SQS, fixes #138

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 .serverless/
 package-lock.json
+.idea

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -316,6 +316,31 @@ constructs:
         delay: 60
 ```
 
+### Encryption
+
+Turn on server-side encryption for the queue.
+
+You can set the `encryption` option to `kmsManaged` to use a SQS managed master key.
+
+```yaml
+constructs:
+    my-queue:
+        # ...
+        # Encryption will be enabled and managed by AWS
+        encryption: 'kmsManaged'
+```
+
+Or you can set it to `kms` and provide your own key via `encryptionKey` option.
+
+```yaml
+constructs:
+    my-queue:
+        # ...
+        # Encryption will be enabled and managed by AWS
+        encryption: 'kms'
+        encryptionKey: 'MySuperSecretKey'
+```
+
 ### Batch size
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@aws-cdk/aws-ec2": "^1.138",
     "@aws-cdk/aws-events": "^1.138",
     "@aws-cdk/aws-iam": "^1.138",
+    "@aws-cdk/aws-kms": "^1.138",
     "@aws-cdk/aws-lambda": "^1.138",
     "@aws-cdk/aws-s3": "^1.138",
     "@aws-cdk/aws-sns": "^1.138",

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -1,4 +1,5 @@
-import { Queue as CdkQueue } from "@aws-cdk/aws-sqs";
+import { Key } from "@aws-cdk/aws-kms";
+import { Queue as CdkQueue, QueueEncryption } from "@aws-cdk/aws-sqs";
 import type { FromSchema } from "json-schema-to-ts";
 import { Alarm, ComparisonOperator, Metric } from "@aws-cdk/aws-cloudwatch";
 import { Subscription, SubscriptionProtocol, Topic } from "@aws-cdk/aws-sns";
@@ -7,6 +8,7 @@ import type { Construct as CdkConstruct } from "@aws-cdk/core";
 import { CfnOutput, Duration } from "@aws-cdk/core";
 import chalk from "chalk";
 import type { PurgeQueueRequest, SendMessageRequest } from "aws-sdk/clients/sqs";
+import { isNil } from "lodash";
 import type { Ora } from "ora";
 import ora from "ora";
 import { spawnSync } from "child_process";
@@ -42,6 +44,8 @@ const QUEUE_DEFINITION = {
         },
         fifo: { type: "boolean" },
         delay: { type: "number" },
+        encryption: { type: "string" },
+        encryptionKey: { type: "string" },
     },
     additionalProperties: false,
     required: ["worker"],
@@ -144,6 +148,29 @@ export class Queue extends AwsConstruct {
             delay = Duration.seconds(configuration.delay);
         }
 
+        let encryption = undefined;
+        if (isNil(configuration.encryption) || configuration.encryption.length === 0) {
+            encryption = {};
+        } else if (configuration.encryption === "kmsManaged") {
+            encryption = { encryption: QueueEncryption.KMS_MANAGED };
+        } else if (configuration.encryption === "kms") {
+            if (isNil(configuration.encryptionKey) || configuration.encryptionKey.length === 0) {
+                throw new ServerlessError(
+                    `Invalid configuration in 'constructs.${this.id}': 'encryptionKey' must be set if the 'encryption' is set to 'kms'`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
+            encryption = {
+                encryption: QueueEncryption.KMS,
+                encryptionMasterKey: new Key(this, configuration.encryptionKey),
+            };
+        } else {
+            throw new ServerlessError(
+                `Invalid configuration in 'constructs.${this.id}': 'encryption' must be one of 'kms', 'kmsManaged', null, '${configuration.encryption}' given.`,
+                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+            );
+        }
+
         const baseName = `${this.provider.stackName}-${id}`;
 
         const dlq = new CdkQueue(this, "Dlq", {
@@ -151,6 +178,7 @@ export class Queue extends AwsConstruct {
             // 14 days is the maximum, we want to keep these messages for as long as possible
             retentionPeriod: Duration.days(14),
             fifo: configuration.fifo,
+            ...encryption,
         });
 
         this.queue = new CdkQueue(this, "Queue", {
@@ -165,6 +193,7 @@ export class Queue extends AwsConstruct {
             fifo: configuration.fifo,
             deliveryDelay: delay,
             contentBasedDeduplication: configuration.fifo,
+            ...encryption,
         });
 
         const alarmEmail = configuration.alarm;


### PR DESCRIPTION
Extended SQS options with `encryption` and `encryptionKey` to enable Server-Side encryption. 
If `encryption` is set to `kmsManaged`, key will be managed by SQS. 
If it is set to `kms`, then `encryptionKey` will be required.

Closes #138