### PR TITLE
Add Access-Control-Request-Method to the list of forwarded headers

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -328,6 +328,7 @@ By default, CloudFront is configured to forward the following HTTP headers to th
 - `User-Agent`
 - `X-Forwarded-Host`
 - `X-Requested-With`
+- `Access-Control-Request-Method`
 
 Why only this list? Because CloudFront + API Gateway requires us to define explicitly the list of headers to forward. It isn't possible to forward _all_ headers.
 

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -390,7 +390,9 @@ export class ServerSideWebsite extends AwsConstruct {
             "User-Agent",
             "X-Requested-With",
             // This header is set by our CloudFront Function
-            "X-Forwarded-Host"
+            "X-Forwarded-Host",
+            // This header is needed for CORS
+            "Access-Control-Request-Method"
         );
     }
 


### PR DESCRIPTION
I (with help from @t-richard) found this small thing that could be a massive improvement. 

I am running a API and want to allow request from my React app. I obviously get issues with CORS but no matter how much I try I failed to solve it...

It turned out to be that Chrome is doing a "preflight" to check CORS headers with an OPTION request. The [NelmioCorsBundle](https://github.com/nelmio/NelmioCorsBundle) is [checking](https://github.com/nelmio/NelmioCorsBundle/blob/2.2.0/EventListener/CorsListener.php#L72) for the Access-Control-Request-Method. If that header does not exist, the preflight will fail. 

I am not sure if this is needed for CORS or if it is needed for CORS with NelmioCorsBundle. I thought I would share it here and hopefully it will help other developers in the same situation. 

--------

The workaround would be to [configure forward headers yourself](https://github.com/getlift/lift/blob/master/docs/server-side-website.md#forwarded-headers) like: 

```yaml
constructs:
    website:
        type: server-side-website
        # ...
        forwardedHeaders:
            - Accept
            - Accept-Language
            - Authorization
            - Content-Type
            - Origin
            - Referer
            - User-Agent
            - X-Forwarded-Host
            - X-Requested-With
            - Access-Control-Request-Method
```