### PR TITLE
Add WebAcl construct support for cloudfront

### DIFF
--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -192,6 +192,19 @@ constructs:
 
 The first domain in the list will be considered the main domain. In this case, `mywebsite.com` will redirect to `www.mywebsite.com`.
 
+### Web ACL
+
+If you have a Web ACL configured in WAF2 or WAF Classing you can link it to the cloudfront distribution:
+
+```yaml
+constructs:
+    website:
+        # ...
+        webAclId: arn:aws:wafv2:us-east-1:{account}:global/webacl/{webacl_name}/{webacl_id}
+```
+
+NOTE: For WAF2, you need to specify the arn as demonstrated in the example. For WAF Classic you must set the ID. 
+
 ### Error page
 
 By default, all 404 requests are redirected to `index.html` with a 200 response status. This behavior is optimized for Single-Page Applications: it allows doing client-side URL routing with JavaScript frameworks.

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -59,6 +59,7 @@ const SCHEMA = {
         redirectToMainDomain: { type: "boolean" },
         certificate: { type: "string" },
         forwardedHeaders: { type: "array", items: { type: "string" } },
+        webAclId: { type: "string" },
     },
     additionalProperties: false,
 } as const;
@@ -172,6 +173,7 @@ export class ServerSideWebsite extends AwsConstruct {
             httpVersion: HttpVersion.HTTP2,
             certificate: certificate,
             domainNames: this.domains,
+            webAclId: configuration.webAclId,
         });
 
         // CloudFormation outputs

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -49,6 +49,7 @@ export const COMMON_STATIC_WEBSITE_DEFINITION = {
         },
         errorPage: { type: "string" },
         redirectToMainDomain: { type: "boolean" },
+        webAclId: { type: "string" },
     },
     additionalProperties: false,
     required: ["path"],
@@ -125,6 +126,7 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             httpVersion: HttpVersion.HTTP2,
             certificate: certificate,
             domainNames: this.domains,
+            webAclId: configuration.webAclId,
         });
 
         // CloudFormation outputs


### PR DESCRIPTION
fixes #178

It's sometimes necessary to protect our cloudfront distribution with a
WAF2/WAF Classic web ACL. A very first simple approach would be to allow linking
an existing WAF resource.

Basically following should be possible:

```yaml
constructs:
    website:
        # ...
        webAclId: arn:aws:wafv2:us-east-1:{account}:global/webacl/{webacl_name}/{webacl_id}
```

## Help

I never contributed on any serverless plugin, so could someone help me out for adding tests and how I can run them on my local machine as out of the box the tests fail. And in the contributing guidelines I didn't find anything specific to that. Thx

- [ ] Adding tests
