### PR TITLE
Add ability to define the distribution comment

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -346,6 +346,43 @@ constructs:
 
 CloudFront accepts maximum 10 headers.
 
+### Define the Distribution comment
+
+By default, the generated comment for the distribution will be `SERVICE-STAGE ID website CDN`.
+The comment will be `my-app-prod website website CDN` if you use that configuration (with `prod` stage):
+
+```yaml
+service: my-app
+provider:
+    name: aws
+
+functions:
+    home:
+        handler: home.handler
+        events:
+            -   httpApi: 'GET /'
+    # ...
+
+constructs:
+    website:
+        type: server-side-website
+        assets:
+            '/css/*': public/css
+            '/js/*': public/js
+
+plugins:
+    - serverless-lift
+```
+
+You can customize that comment by providing it:
+
+```yaml
+constructs:
+    website:
+        # ...
+        comment: My App Cloudfront distrib
+```
+
 ### More options
 
 Looking for more options in the construct configuration? [Open a GitHub issue](https://github.com/getlift/lift/issues/new).

--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -223,6 +223,34 @@ constructs:
             allowIframe: true
 ```
 
+### Define the Distribution comment
+
+By default, the generated comment for the distribution will be `SERVICE-STAGE ID website CDN`.
+The comment will be `my-app-prod landing website CDN` if you use that configuration (with `prod` stage):
+
+```yaml
+service: my-app
+provider:
+    name: aws
+
+constructs:
+    landing:
+        type: static-website
+        path: public
+
+plugins:
+    - serverless-lift
+```
+
+You can customize that comment by providing it:
+
+```yaml
+constructs:
+    landing:
+        # ...
+        comment: My App Cloudfront distrib
+```
+
 ### More options
 
 Looking for more options in the construct configuration? [Open a GitHub issue](https://github.com/getlift/lift/issues/new).

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -59,6 +59,7 @@ const SCHEMA = {
         redirectToMainDomain: { type: "boolean" },
         certificate: { type: "string" },
         forwardedHeaders: { type: "array", items: { type: "string" } },
+        comment: { type: "string" },
     },
     additionalProperties: false,
 } as const;
@@ -144,7 +145,7 @@ export class ServerSideWebsite extends AwsConstruct {
                 : undefined;
 
         this.distribution = new Distribution(this, "CDN", {
-            comment: `${provider.stackName} ${id} website CDN`,
+            comment: configuration.comment ?? `${provider.stackName} ${id} website CDN`,
             defaultBehavior: {
                 // Origins are where CloudFront fetches content
                 origin: new HttpOrigin(apiGatewayDomain, {

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -49,6 +49,7 @@ export const COMMON_STATIC_WEBSITE_DEFINITION = {
         },
         errorPage: { type: "string" },
         redirectToMainDomain: { type: "boolean" },
+        comment: { type: "string" },
     },
     additionalProperties: false,
     required: ["path"],
@@ -107,7 +108,7 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
         ];
 
         this.distribution = new Distribution(this, "CDN", {
-            comment: `${provider.stackName} ${id} website CDN`,
+            comment: configuration.comment ?? `${provider.stackName} ${id} website CDN`,
             // Send all page requests to index.html
             defaultRootObject: "index.html",
             defaultBehavior: {

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -433,6 +433,28 @@ describe("server-side website", () => {
         });
     });
 
+    it("should allow to define the distribution comment", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    backend: {
+                        type: "server-side-website",
+                        comment: "My Project Cloudfront distrib",
+                    },
+                },
+            }),
+        });
+        const cfDistributionLogicalId = computeLogicalId("backend", "CDN");
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Properties: {
+                DistributionConfig: {
+                    Comment: "My Project Cloudfront distrib",
+                },
+            },
+        });
+    });
+
     it("should validate the error page path", async () => {
         await expect(() => {
             return runServerless({

--- a/test/unit/staticWebsites.test.ts
+++ b/test/unit/staticWebsites.test.ts
@@ -403,6 +403,30 @@ describe("static websites", () => {
         });
     });
 
+    it("should allow to define the distribution comment", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            command: "package",
+            config: Object.assign(baseConfig, {
+                constructs: {
+                    landing: {
+                        type: "static-website",
+                        path: ".",
+                        comment: "My Project Cloudfront distrib",
+                    },
+                },
+            }),
+        });
+
+        const cfDistributionLogicalId = computeLogicalId("landing", "CDN");
+        expect(cfTemplate.Resources[cfDistributionLogicalId]).toMatchObject({
+            Properties: {
+                DistributionConfig: {
+                    Comment: "My Project Cloudfront distrib",
+                },
+            },
+        });
+    });
+
     it("should validate the error page path", async () => {
         await expect(() => {
             return runServerless({


### PR DESCRIPTION
I wanted to be able to define the comment of the distribution to follow our internal naming.
So I've added a `comment` options that will be taken as the distribution comment if specified.

I added that option for:
- static-website
- server-side-website

I wasn't 100% sure about the name `comment`. I'm open to new name :)