### PR TITLE
[RFC] Deploy any CDK construct

### DIFF
--- a/src/constructs/aws/CustomCdk.ts
+++ b/src/constructs/aws/CustomCdk.ts
@@ -1,0 +1,46 @@
+import type { FromSchema } from "json-schema-to-ts";
+import type { Construct as CdkConstruct } from "@aws-cdk/core";
+import type { AwsProvider } from "@lift/providers";
+import { AwsConstruct } from "@lift/constructs/abstracts";
+
+const CUSTOM_CDK_DEFINITION = {
+    type: "object",
+    properties: {
+        type: { const: "customCdk" },
+        cdkConstructPath: { type: "string" },
+    },
+    additionalProperties: false,
+    required: ["cdkConstructPath"],
+} as const;
+type Configuration = FromSchema<typeof CUSTOM_CDK_DEFINITION>;
+
+export class CustomCdk extends AwsConstruct {
+    public static type = "customCdk";
+    public static schema = CUSTOM_CDK_DEFINITION;
+
+    private customCdkConstruct: CdkConstruct;
+
+    constructor(
+        scope: CdkConstruct,
+        private readonly id: string,
+        private readonly configuration: Configuration,
+        private readonly provider: AwsProvider
+    ) {
+        super(scope, id);
+
+        // dynamically import the file pointed by the path and compile it if it's a typescript file
+        const cdkConstructClass = importConstruct(this.configuration.cdkConstructPath);
+
+        // Imported file can contain anything. It should be validated
+        checkIsCdkConstruct(cdkConstructClass);
+
+        // The construct is only used to produce CloudFormation. It can't produce side effects such as artefacts upload.
+        checkConstructCanBeDeployed(cdkConstructClass);
+
+        this.customCdkConstruct = new cdkConstructClass(scope, "CdkConstruct");
+    }
+    variables(): Record<string, unknown> {
+        // Expose all the public attributes of the construct
+        return getAllPublicAttributes(this.customCdkConstruct);
+    }
+}

--- a/src/constructs/aws/CustomLift.ts
+++ b/src/constructs/aws/CustomLift.ts
@@ -1,0 +1,65 @@
+import type { FromSchema } from "json-schema-to-ts";
+import type { Construct as CdkConstruct } from "@aws-cdk/core";
+import type { AwsProvider } from "@lift/providers";
+import { AwsConstruct } from "@lift/constructs/abstracts";
+import type { ConstructInterface } from "@lift/constructs";
+import type { PolicyStatement } from "../../CloudFormation";
+
+const CUSTOM_LIFT_DEFINITION = {
+    type: "object",
+    properties: {
+        type: { const: "customLift" },
+        liftConstructPath: { type: "string" },
+        configuration: { type: "object" },
+    },
+    additionalProperties: false,
+    required: ["liftConstructPath"],
+} as const;
+type Configuration = FromSchema<typeof CUSTOM_LIFT_DEFINITION>;
+
+export class CustomLift extends AwsConstruct {
+    public static type = "customLift";
+    public static schema = CUSTOM_LIFT_DEFINITION;
+
+    private customLiftConstruct: ConstructInterface;
+
+    constructor(
+        scope: CdkConstruct,
+        private readonly id: string,
+        private readonly configuration: Configuration,
+        private readonly provider: AwsProvider
+    ) {
+        super(scope, id);
+
+        // dynamically import the file pointed by the path and compile it if it's a typescript file
+        const liftConstructClass = importConstruct(this.configuration.liftConstructPath);
+
+        // Imported file can contain anything. It should be validated
+        checkIsLiftConstruct(liftConstructClass);
+
+        // The construct is only used to produce CloudFormation. It can't produce side effects such as artefacts upload.
+        checkConstructCanBeDeployed(liftConstructClass);
+
+        this.customLiftConstruct = new liftConstructClass(
+            scope,
+            "CDKConstruct",
+            this.configuration.configuration ?? {},
+            provider
+        );
+    }
+    outputs(): Record<string, () => Promise<string | undefined>> {
+        return this.customLiftConstruct.outputs?.() ?? {};
+    }
+    variables(): Record<string, unknown> {
+        return this.customLiftConstruct.variables?.() ?? {};
+    }
+    postDeploy(): Promise<void> {
+        return this.customLiftConstruct.postDeploy?.() ?? Promise.resolve();
+    }
+    preRemove(): Promise<void> {
+        return this.customLiftConstruct.preRemove?.() ?? Promise.resolve();
+    }
+    permissions(): PolicyStatement[] {
+        return this.customLiftConstruct.permissions?.() ?? [];
+    }
+}

--- a/src/constructs/aws/index.ts
+++ b/src/constructs/aws/index.ts
@@ -6,3 +6,4 @@ export { Storage } from "./Storage";
 export { Vpc } from "./Vpc";
 export { Webhook } from "./Webhook";
 export { ServerSideWebsite } from "./ServerSideWebsite";
+export { CustomCdk } from "./CustomCdk";

--- a/src/constructs/aws/index.ts
+++ b/src/constructs/aws/index.ts
@@ -7,3 +7,4 @@ export { Vpc } from "./Vpc";
 export { Webhook } from "./Webhook";
 export { ServerSideWebsite } from "./ServerSideWebsite";
 export { CustomCdk } from "./CustomCdk";
+export { CustomLift } from "./CustomLift";

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -6,6 +6,7 @@ import type { ProviderInterface } from "@lift/providers";
 import type { ConstructInterface, StaticConstructInterface } from "@lift/constructs";
 import {
     CustomCdk,
+    CustomLift,
     DatabaseDynamoDBSingleTable,
     Queue,
     ServerSideWebsite,
@@ -176,5 +177,6 @@ AwsProvider.registerConstructs(
     Vpc,
     DatabaseDynamoDBSingleTable,
     ServerSideWebsite,
-    CustomCdk
+    CustomCdk,
+    CustomLift
 );

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -5,6 +5,7 @@ import type { AwsCfInstruction, AwsLambdaVpcConfig } from "@serverless/typescrip
 import type { ProviderInterface } from "@lift/providers";
 import type { ConstructInterface, StaticConstructInterface } from "@lift/constructs";
 import {
+    CustomCdk,
     DatabaseDynamoDBSingleTable,
     Queue,
     ServerSideWebsite,
@@ -174,5 +175,6 @@ AwsProvider.registerConstructs(
     StaticWebsite,
     Vpc,
     DatabaseDynamoDBSingleTable,
-    ServerSideWebsite
+    ServerSideWebsite,
+    CustomCdk
 );


### PR DESCRIPTION
This is a draft to discuss supporting generic CDK constructs and Lift constructs. Here is how it can be used so far:

```yml
service: app

provider:
    name: aws

constructs:
    myCdkConstruct:
        type: customCdk
        cdkConstructPath: ./cdkConstruct.ts

    myLiftConstruct:
        type: customLift
        cdkConstructPath: ./liftConstruct.ts

plugins:
    - serverless-lift
```