### PR TITLE
Add additional code to viewer request and response cloudfront functions

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -59,6 +59,13 @@ const SCHEMA = {
         redirectToMainDomain: { type: "boolean" },
         certificate: { type: "string" },
         forwardedHeaders: { type: "array", items: { type: "string" } },
+        cloudfrontFunctions: {
+            type: "object",
+            properties: {
+                viewerRequest: { type: "string" },
+                viewerResponse: { type: "string" },
+            },
+        },
     },
     additionalProperties: false,
 } as const;
@@ -416,6 +423,13 @@ export class ServerSideWebsite extends AwsConstruct {
 
         if (this.configuration.redirectToMainDomain === true) {
             additionalCode += redirectToMainDomain(this.domains);
+        }
+
+        if (
+            this.configuration.cloudfrontFunctions &&
+            this.configuration.cloudfrontFunctions.viewerRequest !== undefined
+        ) {
+            additionalCode += this.configuration.cloudfrontFunctions.viewerRequest;
         }
 
         /**

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -170,6 +170,10 @@ export class ServerSideWebsite extends AwsConstruct {
                         function: this.createRequestFunction(),
                         eventType: FunctionEventType.VIEWER_REQUEST,
                     },
+                    {
+                        function: this.createResponseFunction(),
+                        eventType: FunctionEventType.VIEWER_RESPONSE,
+                    },
                 ],
             },
             // All the assets paths are created in there
@@ -416,6 +420,22 @@ export class ServerSideWebsite extends AwsConstruct {
         }
 
         return behaviors;
+    }
+
+    private createResponseFunction(): cloudfront.Function {
+        let code = "";
+
+        if (
+            this.configuration.cloudfrontFunctions &&
+            this.configuration.cloudfrontFunctions.viewerResponse !== undefined
+        ) {
+            code += this.configuration.cloudfrontFunctions.viewerResponse;
+        }
+
+        return new cloudfront.Function(this, "ResponseFunction", {
+            functionName: `${this.provider.stackName}-${this.provider.region}-${this.id}-response`,
+            code: cloudfront.FunctionCode.fromInline(code),
+        });
     }
 
     private createRequestFunction(): cloudfront.Function {


### PR DESCRIPTION
The following PR adds the ability to add additional code to the viewer request Cloudfront function as well as create a viewer response Cloudfront function for the Server Side Website Construct. Cloudfront functions are powerful in their ability to transform the HTTP request without proving much overhead. In my specific case, I needed to add additional code to the viewer request function to redirect an apex domain to a www domain. You may say, why not just use the redirectToMainDomain config? My application is a multi-tenant application that uses a wildcard domain for the tenants. Below is our exact use case. As you can see, the redirect feature would not be useful due to the wildcard domain. I want to redirect publicsafetyrosters.com to www.publicsafetyrosters.com. With this PR, I can now add the additional code to the function.

Existing:
```
website:
  type: server-side-website
  domain:
    - www.publicsafetyrosters.com
    - publicsafetyrosters.com
    - "*.publicsafetyrosters.com"
  certificate: xxxx
  forwardedHeaders:
    - Accept
    - Authorization
    - Content-Type
    - Origin
    - Referer
    - User-Agent
    - X-Forwarded-Host
    - X-Requested-With
    - X-Livewire
    - X-XSRF-TOKEN
    - X-CSRF-TOKEN
```

New:
```
website:
  type: server-side-website
  domain:
    - www.publicsafetyrosters.com
    - publicsafetyrosters.com
    - "*.publicsafetyrosters.com"
  cloudfrontFunctions:
    viewerRequest: `if (request.headers["host"].value === 'publicsafetyrosters.com') {
  var response = {
    statusCode: 302,
    statusDescription: 'Found',
    headers: {
      'location': { value: 'https://www.publicsafetyrosters.com' + request.uri }
    }
  };
  return response;
}
  certificate: xxxx
  forwardedHeaders:
    - Accept
    - Authorization
    - Content-Type
    - Origin
    - Referer
    - User-Agent
    - X-Forwarded-Host
    - X-Requested-With
    - X-Livewire
    - X-XSRF-TOKEN
    - X-CSRF-TOKEN
```

The PR also allows for a viewer response. This example shows how to add a CORS response.
```
website:
  type: server-side-website
  domain:
    - www.publicsafetyrosters.com
    - publicsafetyrosters.com
    - "*.publicsafetyrosters.com"
  cloudfrontFunctions:
    viewerResponse: `function handler(event)  {
  var response = event.response;
  var headers = response.headers;
  if (!headers['access-control-allow-origin']) {
    headers['access-control-allow-origin'] = {value: "*"};
  }
  return response;
}`
certificate: xxxx
```