### PR TITLE
Improve webhooks authorization

### DIFF
--- a/src/constructs/aws/Webhook.ts
+++ b/src/constructs/aws/Webhook.ts
@@ -124,7 +124,7 @@ export class Webhook extends AwsConstruct {
                 authorizerPayloadFormatVersion: "2.0",
                 authorizerType: "REQUEST",
                 name: `${id}-authorizer`,
-                identitySource: ["$request.header.Authorization"],
+                identitySource: [],
                 enableSimpleResponses: true,
                 authorizerUri: Fn.join("/", [
                     `arn:aws:apigateway:${this.provider.region}:lambda:path/2015-03-31/functions`,

--- a/src/constructs/aws/Webhook.ts
+++ b/src/constructs/aws/Webhook.ts
@@ -124,7 +124,6 @@ export class Webhook extends AwsConstruct {
                 authorizerPayloadFormatVersion: "2.0",
                 authorizerType: "REQUEST",
                 name: `${id}-authorizer`,
-                identitySource: [],
                 enableSimpleResponses: true,
                 authorizerUri: Fn.join("/", [
                     `arn:aws:apigateway:${this.provider.region}:lambda:path/2015-03-31/functions`,


### PR DESCRIPTION
I have a bug on my application with Lift: I want to secure a webhook call using with a different header than Authorization (I do not have control on the header).

The HTTP request does not contain an Authorization header and thus receives a 401 error. The documentation: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html

All headers are available in the event anyway, and Lift doesn't implement authorizer caching by default, so we can juste empty the `identitySource` property.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->
