### PR TITLE
Allow more proxy related headers to pass through

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -389,6 +389,9 @@ export class ServerSideWebsite extends AwsConstruct {
             "Referer",
             "User-Agent",
             "X-Requested-With",
+            "X-Forwarded-For",
+            "X-Forwarded-Port",
+            "X-Forwarded-Proto",
             // This header is set by our CloudFront Function
             "X-Forwarded-Host"
         );


### PR DESCRIPTION
Some applications such as wordpress get caught in a redirect loop when these headers are not present.