### PR TITLE
feat(single-page-app): add pdf to redirect regex

### DIFF
--- a/src/constructs/aws/SinglePageApp.ts
+++ b/src/constructs/aws/SinglePageApp.ts
@@ -42,9 +42,9 @@ export class SinglePageApp extends StaticWebsiteAbstract {
          * let static files pass.
          *
          * Files extensions list taken from: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa
-         * Add xml as well
+         * Add pdf and xml as well
          */
-        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml)$)([^.]+$)/;
+        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf)$)([^.]+$)/;
 
 function handler(event) {
     var uri = event.request.uri;

--- a/test/unit/singlePageApp.test.ts
+++ b/test/unit/singlePageApp.test.ts
@@ -29,7 +29,7 @@ describe("single page app", () => {
             Object {
               "Properties": Object {
                 "AutoPublish": true,
-                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml)$)([^.]+$)/;
+                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;
@@ -99,7 +99,7 @@ describe("single page app", () => {
         });
         const requestFunction = computeLogicalId("landing", "RequestFunction");
         expect(cfTemplate.Resources[requestFunction].Properties.FunctionCode).toMatchInlineSnapshot(`
-            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml)$)([^.]+$)/;
+            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;


### PR DESCRIPTION
When trying to serve a pdf as a static file with the single page app contruct, the cloudfront distribution would redirect to index.html because the pdf file extension was not whitelisted. 

This PR adds the pdf file extension to the whitelist so that users can serve pdf files statically.
