### PR TITLE
fix(static-website): re-enable static website hosting

### DIFF
--- a/src/constructs/aws/StaticWebsite.ts
+++ b/src/constructs/aws/StaticWebsite.ts
@@ -57,11 +57,6 @@ export class StaticWebsite extends StaticWebsiteAbstract {
             code: cloudfront.FunctionCode.fromInline(code),
         });
     }
-    /**
-     * Overrides the default `getBucketProps` from the abstract class
-     *
-     * @returns bucketProps
-     */
 
     getBucketProps(): BucketProps {
         return {

--- a/src/constructs/aws/StaticWebsite.ts
+++ b/src/constructs/aws/StaticWebsite.ts
@@ -2,6 +2,8 @@ import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import { FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import type { Construct as CdkConstruct } from "constructs";
 import type { AwsProvider } from "@lift/providers";
+import type { BucketProps } from "aws-cdk-lib/aws-s3";
+import { RemovalPolicy } from "aws-cdk-lib";
 import { redirectToMainDomain } from "../../classes/cloudfrontFunctions";
 import { getCfnFunctionAssociations } from "../../utils/getDefaultCfnFunctionAssociations";
 import type { CommonStaticWebsiteConfiguration } from "./abstracts/StaticWebsiteAbstract";
@@ -54,5 +56,22 @@ export class StaticWebsite extends StaticWebsiteAbstract {
             functionName: `${this.provider.stackName}-${this.provider.region}-${this.id}-request`,
             code: cloudfront.FunctionCode.fromInline(code),
         });
+    }
+    /**
+     * Overrides the default `getBucketProps` from the abstract class
+     *
+     * @returns bucketProps
+     */
+
+    getBucketProps(): BucketProps {
+        return {
+            // Enable static website hosting
+            websiteIndexDocument: "index.html",
+            websiteErrorDocument: this.errorPath(),
+            // public read access is required when enabling static website hosting
+            publicReadAccess: true,
+            // For a static website, the content is code that should be versioned elsewhere
+            removalPolicy: RemovalPolicy.DESTROY,
+        };
     }
 }


### PR DESCRIPTION
The introduction of the single page app construct introduced a breaking change in the static website construct by removing the static website hosting.

This PR re-enables static website hosting and public read access for static buckets.


I also edited the static website tests in order to make them more strict.

Fixes https://github.com/getlift/lift/issues/192

Also see: 
- the initial issue: https://github.com/getlift/lift/issues/172
- the related PR: https://github.com/getlift/lift/pull/175

@adriencaccia
