### PR TITLE
feat(single-table): expose table arn variable

### DIFF
--- a/docs/database-dynamodb-single-table.md
+++ b/docs/database-dynamodb-single-table.md
@@ -39,6 +39,7 @@ The `database/dynamodb-single-table` construct creates and configures the table 
 All database constructs expose the following variables:
 
 - `tableName`: the name of the deployed DynamoDB table
+- `tableArn`: the arn of the deployed DynamoDB table
 - `tableStreamArn`: the ARN of the stream of the deployed DynamoDB table
 
 This can be used to inject the tableName to a Lambda functions using the SDK to read or write data from the table, for example:

--- a/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
+++ b/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
@@ -99,6 +99,7 @@ export class DatabaseDynamoDBSingleTable extends AwsConstruct {
     variables(): Record<string, unknown> {
         return {
             tableName: this.table.tableName,
+            tableArn: this.table.tableArn,
             tableStreamArn: this.table.tableStreamArn,
         };
     }


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->

When working on a project with several serverless services, it is useful to get the table ARN, for instance to create a cloudformation output and use it in other services (rather than building the ARN with the table name).