### PR TITLE
Add CSP header

### DIFF
--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -315,6 +315,9 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             "x-content-type-options": { value: "nosniff" },
             "x-xss-protection": { value: "1; mode=block" },
             "strict-transport-security": { value: "max-age=63072000" },
+            "content-security-policy": {
+                value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'",
+            },
         };
         if (this.configuration.security?.allowIframe === true) {
             delete securityHeaders["x-frame-options"];

--- a/test/unit/staticWebsite.test.ts
+++ b/test/unit/staticWebsite.test.ts
@@ -174,6 +174,9 @@ describe("static websites", () => {
     },
     "strict-transport-security": {
         "value": "max-age=63072000"
+    },
+    "content-security-policy": {
+        "value": "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
     }
 }, response.headers);
     return response;
@@ -301,6 +304,9 @@ describe("static websites", () => {
     },
     "strict-transport-security": {
         "value": "max-age=63072000"
+    },
+    "content-security-policy": {
+        "value": "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
     }
 }, response.headers);
     return response;


### PR DESCRIPTION
Following recommendations from [AWS Documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-security-headers.html), header [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) should be added in CloudFront responses.