### PR TITLE
feat(static-website): allow empty params

### DIFF
--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -94,9 +94,14 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
         const bucket = new Bucket(this, "Bucket", bucketProps);
 
         // Cast the domains to an array
-        this.domains = configuration.domain !== undefined ? flatten([configuration.domain]) : undefined;
+        // if configuration.domain is an empty array or an empty string, ignore it
+        this.domains =
+            configuration.domain !== undefined && configuration.domain.length > 0
+                ? flatten([configuration.domain])
+                : undefined;
+        // if configuration.certificate is an empty string, ignore it
         const certificate =
-            configuration.certificate !== undefined
+            configuration.certificate !== undefined && configuration.certificate !== ""
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)
                 : undefined;
 
@@ -134,9 +139,9 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             value: bucket.bucketName,
         });
         let websiteDomain: string = this.distribution.distributionDomainName;
-        if (configuration.domain !== undefined) {
+        if (this.domains !== undefined) {
             // In case of multiple domains, we take the first one
-            websiteDomain = typeof configuration.domain === "string" ? configuration.domain : configuration.domain[0];
+            websiteDomain = this.domains[0];
         }
         this.domainOutput = new CfnOutput(this, "Domain", {
             description: "Website domain name.",

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -81,14 +81,6 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
     ) {
         super(scope, id);
 
-        if (configuration.domain !== undefined && configuration.certificate === undefined) {
-            throw new ServerlessError(
-                `Invalid configuration for the static website '${id}': if a domain is configured, then a certificate ARN must be configured in the 'certificate' option.\n` +
-                    "See https://github.com/getlift/lift/blob/master/docs/static-website.md#custom-domain",
-                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
-            );
-        }
-
         const bucketProps = this.getBucketProps();
 
         const bucket = new Bucket(this, "Bucket", bucketProps);
@@ -104,6 +96,14 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             configuration.certificate !== undefined && configuration.certificate !== ""
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)
                 : undefined;
+
+        if (this.domains !== undefined && certificate === undefined) {
+            throw new ServerlessError(
+                `Invalid configuration for the static website '${id}': if a domain is configured, then a certificate ARN must be configured in the 'certificate' option.\n` +
+                    "See https://github.com/getlift/lift/blob/master/docs/static-website.md#custom-domain",
+                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+            );
+        }
 
         const functionAssociations = [
             {


### PR DESCRIPTION
Hello!

When using the `static-website` construct, I wanted to use Serverless V3 Stage params to define the settings for my static websites.

I didn't want to define a certificate and custom domains for my dev environment, so I tried to pass an empty string and an empty array instead. The Serverless framework remove `null` arguments so this wasn't an option.

Check out the PR in which I wanted to use this feature: https://github.com/swarmion/swarmion/pull/134

However these options were not handled by Lift before passing them to the CDK.

This PR adds the possibility to pass empty arguments for `certificate` and `domain` configurations.

What do you think?