### PR TITLE
fix(aws): bootstrap functions key in services and not configurationInput

### DIFF
--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -15,7 +15,12 @@ import {
     Webhook,
 } from "@lift/constructs/aws";
 import { getStackOutput } from "../CloudFormation";
-import type { CloudformationTemplate, Provider as LegacyAwsProvider, Serverless } from "../types/serverless";
+import type {
+    CloudformationTemplate,
+    LambdaFunction,
+    Provider as LegacyAwsProvider,
+    Serverless,
+} from "../types/serverless";
 import { awsRequest } from "../classes/aws";
 import ServerlessError from "../utils/error";
 
@@ -94,7 +99,7 @@ export class AwsProvider implements ProviderInterface {
         return Construct.create(this, id, configuration);
     }
 
-    addFunction(functionName: string, functionConfig: unknown): void {
+    addFunction(functionName: string, functionConfig?: LambdaFunction): void {
         if (!this.serverless.configurationInput.functions) {
             // If serverless.yml does not contain any functions, bootstrapping a new empty functions config
             this.serverless.configurationInput.functions = {};

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -100,9 +100,9 @@ export class AwsProvider implements ProviderInterface {
     }
 
     addFunction(functionName: string, functionConfig?: LambdaFunction): void {
-        if (!this.serverless.configurationInput.functions) {
+        if (!this.serverless.service.functions) {
             // If serverless.yml does not contain any functions, bootstrapping a new empty functions config
-            this.serverless.configurationInput.functions = {};
+            this.serverless.service.functions = {};
         }
 
         Object.assign(this.serverless.service.functions, {

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -105,7 +105,7 @@ export class AwsProvider implements ProviderInterface {
             this.serverless.service.functions = {};
         }
 
-        Object.assign(this.serverless.service.functions, {
+        merge(this.serverless.service.functions, {
             [functionName]: functionConfig,
         });
         /**

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -80,3 +80,5 @@ export type CommandsDefinition = Record<
 >;
 
 export type CliOptions = Record<string, string | boolean | string[]>;
+
+export type LambdaFunction = Exclude<AWS["functions"], undefined>[string];

--- a/test/unit/storage.test.ts
+++ b/test/unit/storage.test.ts
@@ -27,7 +27,9 @@ describe("storage", () => {
                         ],
                     },
                     {
-                        NoncurrentVersionExpirationInDays: 30,
+                        NoncurrentVersionExpiration: {
+                            NoncurrentDays: 30,
+                        },
                         Status: "Enabled",
                     },
                 ],


### PR DESCRIPTION
All tests are currently failing on the master branch.

![image](https://user-images.githubusercontent.com/29537204/170702593-48f6b79d-eb82-44a1-b4d1-ad51d8aba021.png)

I believe the reason is that `Object.assign` to replace an empty functions config was applied to `configurationInput` and not `services`

This PR fixes this build issue.

What do you think?
