### PR TITLE
feat(static-website): allow empty params

### DIFF
--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -94,9 +94,14 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
         const bucket = new Bucket(this, "Bucket", bucketProps);
 
         // Cast the domains to an array
-        this.domains = configuration.domain !== undefined ? flatten([configuration.domain]) : undefined;
+        // if configuration.domain is an empty array or an empty string, ignore it
+        this.domains =
+            configuration.domain !== undefined && configuration.domain.length > 0
+                ? flatten([configuration.domain])
+                : undefined;
+        // if configuration.certificate is an empty string, ignore it
         const certificate =
-            configuration.certificate !== undefined
+            configuration.certificate !== undefined && configuration.certificate !== ""
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)
                 : undefined;
 
@@ -134,9 +139,9 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             value: bucket.bucketName,
         });
         let websiteDomain: string = this.distribution.distributionDomainName;
-        if (configuration.domain !== undefined) {
+        if (this.domains !== undefined) {
             // In case of multiple domains, we take the first one
-            websiteDomain = typeof configuration.domain === "string" ? configuration.domain : configuration.domain[0];
+            websiteDomain = this.domains[0];
         }
         this.domainOutput = new CfnOutput(this, "Domain", {
             description: "Website domain name.",

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -81,14 +81,6 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
     ) {
         super(scope, id);
 
-        if (configuration.domain !== undefined && configuration.certificate === undefined) {
-            throw new ServerlessError(
-                `Invalid configuration for the static website '${id}': if a domain is configured, then a certificate ARN must be configured in the 'certificate' option.\n` +
-                    "See https://github.com/getlift/lift/blob/master/docs/static-website.md#custom-domain",
-                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
-            );
-        }
-
         const bucketProps = this.getBucketProps();
 
         const bucket = new Bucket(this, "Bucket", bucketProps);
@@ -104,6 +96,14 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
             configuration.certificate !== undefined && configuration.certificate !== ""
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)
                 : undefined;
+
+        if (this.domains !== undefined && certificate === undefined) {
+            throw new ServerlessError(
+                `Invalid configuration for the static website '${id}': if a domain is configured, then a certificate ARN must be configured in the 'certificate' option.\n` +
+                    "See https://github.com/getlift/lift/blob/master/docs/static-website.md#custom-domain",
+                "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+            );
+        }
 
         const functionAssociations = [
             {


### PR DESCRIPTION
Follow-up of #213 which was unfortunately closed

What I need to do is parametrize some of my config:
```
  constructs: {
    app: {
      type: 'static-website',
      path: '../build',
      errorPage: '404.html',
      domain: '${param:domain}',
      redirectToMainDomain: '${param:redirectToMainDomain}',
      certificate: '${param:certificate}',
    },
  },
```

However if I try to setup my params with null values, they get cleaned out from stage params.
```
  params: {
    dev: {
      domain: [],
      redirectToMainDomain: false,
      certificate: null, // issue here
    },
    production: {
      domain: ['www.mywebsite.com', 'mywebsite.com'],
      redirectToMainDomain: true,
      certificate: 'my-certificate-arn',
    },
  },
```

If I do this, I get the following error:
![image](https://user-images.githubusercontent.com/29537204/170698327-c2f7e731-58df-46fe-bdf9-17924e2c8aa3.png)

And if I try to put the params like:
```
  params: {
    dev: {
      domain: [],
      redirectToMainDomain: false,
      certificate: '' // with an empty string
    },
    production: {
      domain: ['www.mywebsite.com', 'mywebsite.com'],
      redirectToMainDomain: true,
      certificate: 'my-certificate-arn',
    },
  },
```
I get the following error:
![image](https://user-images.githubusercontent.com/29537204/170698595-0592edf1-306b-4d0d-8cbb-8ece2cabff26.png)



This PR adds the possibility to pass empty arguments for `certificate` and `domain` configurations.

