### PR TITLE
Add support for retention period

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -320,7 +320,7 @@ constructs:
 
 When a message is sent to the queue, it will be retained for up to 4 days before being automatically deleted.
 
-You can adjust this rentention period to be shorter or longer by specifing a time a seconds.
+You can adjust this rentention period to be shorter or longer by specifing a time in seconds.
 
 The maximum value is 1209600 seconds (14 days) and the minimum value is 60 seconds (1 minute).
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -316,6 +316,22 @@ constructs:
         delay: 60
 ```
 
+### Retention Period
+
+When a message is sent to the queue, it will be retained for up to 4 days before being automatically deleted.
+
+You can adjust this rentention period to be shorter or longer by specifing a time a seconds.
+
+The maximum value is 1209600 seconds (14 days) and the minimum value is 60 seconds (1 minute).
+
+```yaml
+constructs:
+    my-queue:
+        # ...
+        # Message will be retained for at most 60 seconds before being deleted and sent to the DLQ
+        retentionPeriod: 60
+```
+
 ### Encryption
 
 Turn on server-side encryption for the queue.

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -51,7 +51,11 @@ const QUEUE_DEFINITION = {
         },
         fifo: { type: "boolean" },
         delay: { type: "number" },
-        retentionPeriod: { type: "number" },
+        retentionPeriod: {
+            type: "number",
+            minimum: 60,
+            maximum: 1209600,
+        },
         encryption: { type: "string" },
         encryptionKey: { type: "string" },
     },

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -51,6 +51,7 @@ const QUEUE_DEFINITION = {
         },
         fifo: { type: "boolean" },
         delay: { type: "number" },
+        retentionPeriod: { type: "number" },
         encryption: { type: "string" },
         encryptionKey: { type: "string" },
     },
@@ -203,6 +204,10 @@ export class Queue extends AwsConstruct {
             fifo: configuration.fifo,
             deliveryDelay: delay,
             contentBasedDeduplication: configuration.fifo,
+            retentionPeriod:
+                typeof configuration.retentionPeriod === "number"
+                    ? Duration.seconds(configuration.retentionPeriod)
+                    : Duration.days(4),
             ...encryption,
         });
 

--- a/test/unit/queues.test.ts
+++ b/test/unit/queues.test.ts
@@ -245,6 +245,25 @@ describe("queues", () => {
         });
     });
 
+    it("allows changing the retention period", async () => {
+        const { cfTemplate, computeLogicalId } = await runServerless({
+            fixture: "queues",
+            configExt: merge({}, pluginConfigExt, {
+                constructs: {
+                    emails: {
+                        retentionPeriod: 120,
+                    },
+                },
+            }),
+            command: "package",
+        });
+        expect(cfTemplate.Resources[computeLogicalId("emails", "Queue")]).toMatchObject({
+            Properties: {
+                MessageRetentionPeriod: 120,
+            },
+        });
+    });
+
     it("allows changing the encryption to kmsManaged", async () => {
         const { cfTemplate, computeLogicalId } = await runServerless({
             fixture: "queues",


### PR DESCRIPTION
Add support message `retentionPeriod` when creating an SQS queue.

Use case should be self explanatory: we want to adjust the default behavior of 4 days to be shorter or longer.
