### PR TITLE
Fix doc about distribution comment config

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -360,7 +360,8 @@ constructs:
         extensions:
             distribution:
                 Properties:
-                    Comment: Landing distribution
+                    DistributionConfig:
+                        Comment: Landing distribution
 ```
 
 ### Available extensions


### PR DESCRIPTION
`Comment` is defined inside the `DistributionConfig` key, not directly in the `Properties` key.
https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html

Otherwise it generates an error in Cloudformation:

> Properties validation failed for resource websiteCDN060D946D with message: #: extraneous key [Comment] is not permitted
