### PR TITLE
Server-side website: validate asset paths

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -408,6 +408,12 @@ export class ServerSideWebsite extends AwsConstruct {
     private createCacheBehaviors(bucket: Bucket): Record<string, BehaviorOptions> {
         const behaviors: Record<string, BehaviorOptions> = {};
         for (const pattern of Object.keys(this.getAssetPatterns())) {
+            if (pattern === "/" || pattern === "/*") {
+                throw new ServerlessError(
+                    `Invalid key in 'constructs.${this.id}.assets': '/' and '/*' cannot be routed to assets because the root URL already serves the backend application running in Lambda. You must use a sub-path instead, for example '/assets/*'.`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
             behaviors[pattern] = {
                 // Origins are where CloudFront fetches content
                 origin: new S3Origin(bucket),

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -451,6 +451,26 @@ describe("server-side website", () => {
         );
     });
 
+    it("should validate the assets configuration", async () => {
+        await expect(() => {
+            return runServerless({
+                command: "package",
+                config: Object.assign(baseConfig, {
+                    constructs: {
+                        backend: {
+                            type: "server-side-website",
+                            assets: {
+                                "/": "public",
+                            },
+                        },
+                    },
+                }),
+            });
+        }).rejects.toThrowError(
+            "Invalid key in 'constructs.backend.assets': '/' and '/*' cannot be routed to assets because the root URL already serves the backend application running in Lambda. You must use a sub-path instead, for example '/assets/*'."
+        );
+    });
+
     it("should allow to redirect to the main domain", async () => {
         const { cfTemplate, computeLogicalId } = await runServerless({
             command: "package",


### PR DESCRIPTION
The goal is to prevent confusion when trying to set this up (cannot work):

```yaml
constructs:
  assets:
    type: server-side-website
    assets:
      '/*': public
```

Reported in https://github.com/brefphp/bref/discussions/1243