### PR TITLE
Expose bucketName variable in server-side-website

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -159,6 +159,24 @@ resources:
                     DNSName: ${construct:website.cname}
 ```
 
+- `assetsBucketName`: the S3 assets bucketname
+
+This can be used to configure a S3 bucket policy for example:
+
+```yaml
+constructs:
+    website:
+        type: server-side-website
+        # ...
+resources:
+    Resources:
+        BucketPolicy:
+            Type: AWS::S3::BucketPolicy
+            Properties:
+                Bucket: ${construct:website.assetsBucketName}
+                # ...
+```
+
 ## Commands
 
 `serverless deploy` deploys everything configured in `serverless.yml` and uploads assets.

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -222,6 +222,7 @@ export class ServerSideWebsite extends AwsConstruct {
         return {
             url: Fn.join("", ["https://", domain]),
             cname: this.distribution.distributionDomainName,
+            assetsBucketName: this.bucket.bucketName,
         };
     }
 


### PR DESCRIPTION
I needed the created assets bucket name to reference it in a BucketPolicy. So I've exposed the bucketname as a variable (like in the storage construct)