### PR TITLE
fix: Remove manual construction of cloudfront function name to avoid max length constraint

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -457,7 +457,6 @@ export class ServerSideWebsite extends AwsConstruct {
 }`;
 
         return new cloudfront.Function(this, "RequestFunction", {
-            functionName: `${this.provider.stackName}-${this.provider.region}-${this.id}-request`,
             code: cloudfront.FunctionCode.fromInline(code),
         });
     }


### PR DESCRIPTION
Fixes #242 