### PR TITLE
Allow s3 public read access property to be selected

### DIFF
--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -192,6 +192,31 @@ constructs:
 
 The first domain in the list will be considered the main domain. In this case, `mywebsite.com` will redirect to `www.mywebsite.com`.
 
+### Public Read Access
+
+When using CloudFront to cache a static website placed in an S3 bucket, it is possible to host the website without allowing public read access to the S3 bucket, so `publicReadAccess` is set to false by default.
+
+If for some reason you want to allow public read access to S3 bucket, write as follows.
+
+```yaml
+constructs:
+    landing:
+        # ...
+        publicReadAccess: false
+```
+
+### Index Page
+
+You can host a static website using only S3 by setting public read access to true and index page. At the same time, public read access to S3 must be allowed.
+
+```yaml
+constructs:
+    landing:
+        # ...
+        publicReadAccess: true
+        indexPage: index.html
+```
+
 ### Error page
 
 By default, all 404 requests are redirected to `index.html` with a 200 response status. This behavior is optimized for Single-Page Applications: it allows doing client-side URL routing with JavaScript frameworks.

--- a/src/constructs/aws/StaticWebsite.ts
+++ b/src/constructs/aws/StaticWebsite.ts
@@ -67,10 +67,10 @@ export class StaticWebsite extends StaticWebsiteAbstract {
     getBucketProps(): BucketProps {
         return {
             // Enable static website hosting
-            websiteIndexDocument: "index.html",
+            websiteIndexDocument: this.indexPath(),
             websiteErrorDocument: this.errorPath(),
             // public read access is required when enabling static website hosting
-            publicReadAccess: true,
+            publicReadAccess: this.configuration.publicReadAccess ?? false,
             // For a static website, the content is code that should be versioned elsewhere
             removalPolicy: RemovalPolicy.DESTROY,
         };

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -50,6 +50,8 @@ export const COMMON_STATIC_WEBSITE_DEFINITION = {
             },
             additionalProperties: false,
         },
+        publicReadAccess: { type: "boolean" },
+        indexPage: { type: "string" },
         errorPage: { type: "string" },
         redirectToMainDomain: { type: "boolean" },
     },
@@ -279,6 +281,24 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
 
     async getDistributionId(): Promise<string | undefined> {
         return this.provider.getStackOutput(this.distributionIdOutput);
+    }
+
+    indexPath(): string | undefined {
+        if (this.configuration.indexPage !== undefined) {
+            let indexPath = this.configuration.indexPage;
+            if (indexPath.startsWith("./") || indexPath.startsWith("../")) {
+                throw new ServerlessError(
+                    `The 'indexPage' option of the '${this.id}' static website cannot start with './' or '../'. ` +
+                        `(it cannot be a relative path).`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
+            if (!indexPath.startsWith("/")) {
+                indexPath = `/${indexPath}`;
+            }
+
+            return indexPath;
+        }
     }
 
     errorPath(): string | undefined {


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->

I always use serverless-lift through redwoodjs. Thanks for the great package! When I created a static website using this package, I noticed that the publicReadAccess of the S3 bucket was set to true.

I think Lift is written on the premise of caching static websites in S3 bucket with CloudFront. However, when CloudFront is used as a CDN for a static website in an S3 bucket, it is not necessary to set S3 publicReadAccess to true.
In lift, even if publicReadAccess of S3 bucket is set to false using the `extensions` property, it is explicitly set to true in the `src/constructs/aws/StaticWebsite.ts`, so it could not be set using only the `extensions` property.

So I modified the program to allow the user to choose true or false for publicReadAccess.

If you don't mind, please check out this Pull Request!


