### PR TITLE
Allow attachment of worker to Dead-letter queue

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -33,6 +33,7 @@ The `queue` construct deploys the following resources:
 - A `worker` Lambda function: this function processes every message sent to the queue.
 - An SQS "[dead letter queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)": this queue stores all the messages that failed to be processed.
 - Optionally, a CloudWatch alarm that sends an email when the dead letter queue contains failed messages.
+- Optionally, a dead letter queue worker that can process messages sent to the dlq
 
 <img src="img/queue.png" width="600"/>
 
@@ -237,6 +238,21 @@ constructs:
 ```
 
 _Note: Lift will automatically configure the function to be triggered by SQS. It is not necessary to define `events` on the function._
+
+### Dead Letter Queue Worker
+```yaml
+constructs:
+    my-queue:
+        type: queue
+        worker:
+            # The main Lambda function is configured here
+            handler: src/worker.handler
+        dlqWorker:
+            # The DLQ Lambda function is configured here
+            handler: src/dlqWorker.handler
+```
+
+The dead letter queue worker syntax is identical to the main worker. Messages sent to the dead letter queue will be handled by the worker specified under `dlqWorker` 
 
 ### Alarm
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -116,7 +116,7 @@ All queue constructs expose the following variables:
 - `queueUrl`: the URL of the deployed SQS queue
 - `queueArn`: the ARN of the deployed SQS queue
 - `dlqUrl`: the URL of the deployed SQS dead letter queue
-- `queueArn`: the ARN of the deployed SQS dead letter queue
+- `dlqArn`: the ARN of the deployed SQS dead letter queue
 
 These can be used to reference the queue from other Lambda functions, for example:
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -33,7 +33,6 @@ The `queue` construct deploys the following resources:
 - A `worker` Lambda function: this function processes every message sent to the queue.
 - An SQS "[dead letter queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)": this queue stores all the messages that failed to be processed.
 - Optionally, a CloudWatch alarm that sends an email when the dead letter queue contains failed messages.
-- Optionally, a dead letter queue worker that can process messages sent to the dlq
 
 <img src="img/queue.png" width="600"/>
 
@@ -116,6 +115,8 @@ All queue constructs expose the following variables:
 
 - `queueUrl`: the URL of the deployed SQS queue
 - `queueArn`: the ARN of the deployed SQS queue
+- `dlqUrl`: the URL of the deployed SQS dead letter queue
+- `queueArn`: the ARN of the deployed SQS dead letter queue
 
 These can be used to reference the queue from other Lambda functions, for example:
 
@@ -238,21 +239,6 @@ constructs:
 ```
 
 _Note: Lift will automatically configure the function to be triggered by SQS. It is not necessary to define `events` on the function._
-
-### Dead Letter Queue Worker
-```yaml
-constructs:
-    my-queue:
-        type: queue
-        worker:
-            # The main Lambda function is configured here
-            handler: src/worker.handler
-        dlqWorker:
-            # The DLQ Lambda function is configured here
-            handler: src/dlqWorker.handler
-```
-
-The dead letter queue worker syntax is identical to the main worker. Messages sent to the dead letter queue will be handled by the worker specified under `dlqWorker` 
 
 ### Alarm
 

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -37,13 +37,6 @@ const QUEUE_DEFINITION = {
             },
             additionalProperties: true,
         },
-        dlqWorker: {
-            type: "object",
-            properties: {
-                timeout: { type: "number" },
-            },
-            additionalProperties: true,
-        },
         maxRetries: { type: "number" },
         alarm: { type: "string" },
         batchSize: {
@@ -307,9 +300,9 @@ export class Queue extends AwsConstruct {
         const batchSize = this.configuration.batchSize ?? 1;
         const maximumBatchingWindow = this.getMaximumBatchingWindow();
 
-        // Override events for the queue worker
+        // Override events for the worker
         this.configuration.worker.events = [
-            // Subscribe the queue worker to the SQS queue
+            // Subscribe the worker to the SQS queue
             {
                 sqs: {
                     arn: this.queue.queueArn,
@@ -320,23 +313,6 @@ export class Queue extends AwsConstruct {
             },
         ];
         this.provider.addFunction(`${this.id}Worker`, this.configuration.worker);
-
-        if (this.configuration.dlqWorker) {
-            // Override events for the dlq worker
-            this.configuration.dlqWorker.events = [
-                // Subscribe the dlq worker to the SQS queue
-                {
-                    sqs: {
-                        arn: this.dlq.queueArn,
-                        batchSize: batchSize,
-                        maximumBatchingWindow: maximumBatchingWindow,
-                        functionResponseType: "ReportBatchItemFailures",
-                    },
-                },
-            ];
-
-            this.provider.addFunction(`${this.id}DlqWorker`, this.configuration.dlqWorker);
-        }
     }
 
     private async getQueueUrl(): Promise<string | undefined> {

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -119,7 +119,6 @@ export class Queue extends AwsConstruct {
     private readonly dlq: CdkQueue;
     private readonly queueArnOutput: CfnOutput;
     private readonly queueUrlOutput: CfnOutput;
-    private readonly dlqArnOutput: CfnOutput;
     private readonly dlqUrlOutput: CfnOutput;
 
     constructor(
@@ -251,10 +250,6 @@ export class Queue extends AwsConstruct {
         this.queueUrlOutput = new CfnOutput(this, "QueueUrl", {
             description: `URL of the "${id}" SQS queue.`,
             value: this.queue.queueUrl,
-        });
-        this.dlqArnOutput = new CfnOutput(this, "DlqArn", {
-            description: `ARN of the "${id}" SQS dead letter queue.`,
-            value: this.dlq.queueArn,
         });
         this.dlqUrlOutput = new CfnOutput(this, "DlqUrl", {
             description: `URL of the "${id}" SQS dead letter queue.`,


### PR DESCRIPTION
References Issue #188 

Changes aimed at allowing a worker to be assigned as a handler to the dead letter queue. Also publishing the dlq ARN to the yaml file - similar to how the main queue ARN 

Reasons:
* It was difficult to add a worker to a DLQ compared to how easy it was to add one to the main queue
* It would have required manually inserting the ARN into the YAML after having created the queue
* Allowing additional manipulation of the DLQ due to exposure of it's ARN in the YAML file