### PR TITLE
Allow existing SNS topic for DLQ SQS alarms

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -242,16 +242,27 @@ _Note: Lift will automatically configure the function to be triggered by SQS. It
 
 ### Alarm
 
+It is possible to configure email alerts in case messages end up in the dead letter queue.
+
+After the first deployment, an email will be sent to the email address to confirm the subscription.
+
 ```yaml
 constructs:
     my-queue:
         # ...
+        # Email alerts will be sent to alerting@mycompany.com
         alarm: alerting@mycompany.com
 ```
 
-It is possible to configure email alerts in case messages end up in the dead letter queue.
+Or you can specify an existing SNS topic for alerts. The alarm will send to the existing topic for `Alarm` and `OK` messages.
 
-After the first deployment, an email will be sent to the email address to confirm the subscription.
+```yaml
+constructs:
+    my-queue:
+        # ...
+        # Alarm and Ok messages will be sent to an existing SNS topic
+        alarm: arn:aws:sns:us-east-1:123456789012:alarm-alerts
+```
 
 ### FIFO (First-In-First-Out)
 


### PR DESCRIPTION
References issue #277

We have existing alerting looking for `Alarm` and `OK` message posted to a specific SNS topic.

This change allows you to specify an existing SNS topic ARN for `alarm` on the DLQ SQS queue alarm construct. When an ARN that begins with `arn:aws:sns:` is present, that topic is used as an `AlarmAction` and `OKAction` instead of creating a new topic and email subscription.

No changes are made if an email address is specified for `alarm`.

Additionally adds checking for a bare-minimum of an ARN prefix or `@` in `alarm` and throwing an exception if neither is present.
