### PR TITLE
Correct misleading deduplication documentation

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -264,7 +264,19 @@ constructs:
 
 [SQS FIFO](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html) queues provide strict message ordering guarantees. Configuring a FIFO queue is as easy as provding the `fifo: true` option on your construct. This will ensure both the main and Dead-Letter-Queue are configured as FIFO.
 
-By default, FIFO queues have [content-based deduplication](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-exactly-once-processing.html) enabled by default. It is possible to skip that deduplication behavior by publishing messages to SQS [with deduplication IDs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html).
+By default, FIFO queues have [content-based deduplication](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-exactly-once-processing.html) enabled by default. You must disable content based deduplication explicitly if you want to deduplicate using unique deduplication ids. See the SQS documentation for more information on [deduplication ids](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html).
+
+To disable content based deduplication you must use a custom extension:
+
+```
+constructs:
+    my-queue:
+        # ...
+        extensions:
+            queue:
+                Properties:
+                    ContentBasedDeduplication: false
+```
 
 ### Retries
 


### PR DESCRIPTION
Content based deduplication MUST be explicitly disabled to support sending deduplication IDs. I've been hunting down a bug for months trying to figure out what's going wrong. Setting a deduplication ID with content based deduplication enabled does nothing - it still uses the body.