### PR TITLE
Simplify server-side-website with the new AllViewerExceptHostHeader policy

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -335,34 +335,13 @@ Applications are of course free to catch errors and display custom error pages. 
 
 ### Forwarded headers
 
-By default, CloudFront is configured to forward the following HTTP headers to the backend running on Lambda:
+> **Note**:
+> 
+> In previous Lift versions, the headers forwarded to your Lambda backend were limited. You were able to add new headers via the `forwardedHeaders` option.
+> 
+> [This is no longer the case](https://twitter.com/cristiangraz/status/1628585607479050240): **all headers are now always forwarded**.
 
-- `Accept`
-- `Accept-Language`
-- `Authorization`
-- `Content-Type`
-- `Origin`
-- `Referer`
-- `User-Agent`
-- `X-Forwarded-Host`
-- `X-Requested-With`
-
-Why only this list? Because CloudFront + API Gateway requires us to define explicitly the list of headers to forward. It isn't possible to forward _all_ headers.
-
-To access more headers from the client (or [from CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html)), you can redefine the list of headers forwarded by CloudFront in `forwardedHeaders`:
-
-```yaml
-constructs:
-    website:
-        # ...
-        forwardedHeaders:
-            - Accept
-            - Accept-Language
-            # ...
-            - X-Custom-Header
-```
-
-CloudFront accepts maximum 10 headers.
+All headers are forwarded to your Lambda backend. If you used the `forwardedHeaders` option in the past, you can safely remove it.
 
 ## Extensions
 


### PR DESCRIPTION
CloudFront added a new `AllViewerExceptHostHeader` policy: https://twitter.com/cristiangraz/status/1628585607479050240

This is exactly what we needed!

We can get rid of:

- our custom "origin policy" (it was needed to avoid forwarding the Host header)
- our custom "cache policy" (it was needed to forward the Authorization header)

We gain:

- less code for us
- less config for users 🎉
- less resources to deploy, meaning faster deployments 🎉
- users don't have to choose or configure the headers they want to forward 🎉
- users are no longer limited by the limit of 10 forwarded headers 🎉

If you were setting the `forwardedHeader` config in `serverless.yml` to add more headers to forward, you can now safely remove this option:

```yaml
constructs:
    website:
        # ...

        # REMOVE THIS 👇
        forwardedHeaders:
            - Accept
            - Accept-Language
            # ...
            - X-Custom-Header
```

We also finally solve 100% properly #144

Fixes #144
Fixes #229
Fixes #291
and so many more in bref.sh 🎉