### PR TITLE
Expose assets bucket name to static-website and single-page-app

### DIFF
--- a/docs/single-page-app.md
+++ b/docs/single-page-app.md
@@ -125,6 +125,24 @@ resources:
 
 _How it works: the `${construct:landing.cname}` variable will automatically be replaced with a CloudFormation reference to the CloudFront Distribution._
 
+- `assetsBucketName`: the S3 assets bucketname
+
+This can be used to configure a S3 bucket policy for example:
+
+```yaml
+constructs:
+    landing:
+        type: single-page-app
+        # ...
+resources:
+    Resources:
+        BucketPolicy:
+            Type: AWS::S3::BucketPolicy
+            Properties:
+                Bucket: ${construct:landing.assetsBucketName}
+                # ...
+```
+
 ## Configuration reference
 
 ### Path

--- a/docs/static-website.md
+++ b/docs/static-website.md
@@ -111,6 +111,24 @@ resources:
 
 _How it works: the `${construct:landing.cname}` variable will automatically be replaced with a CloudFormation reference to the CloudFront Distribution._
 
+- `assetsBucketName`: the S3 assets bucketname
+
+This can be used to configure a S3 bucket policy for example:
+
+```yaml
+constructs:
+    landing:
+        type: static-website
+        # ...
+resources:
+    Resources:
+        BucketPolicy:
+            Type: AWS::S3::BucketPolicy
+            Properties:
+                Bucket: ${construct:landing.assetsBucketName}
+                # ...
+```
+
 ## Configuration reference
 
 ### Path

--- a/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
+++ b/src/constructs/aws/abstracts/StaticWebsiteAbstract.ts
@@ -162,6 +162,7 @@ export abstract class StaticWebsiteAbstract extends AwsConstruct {
     variables(): Record<string, unknown> {
         return {
             cname: this.distribution.distributionDomainName,
+            assetsBucketName: this.bucket.bucketName,
         };
     }
 


### PR DESCRIPTION
Hi,

Similar to #241, exposing the assets bucket name for the static website and spa constructs.
My use case:
I want to trigger an event after objects are created in the bucket so a Lambda can add some metadata to each file uploaded in that folder (Cache Control headers etc...)
