### PR TITLE
Rewrite disable auto permission test

### DIFF
--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -115,15 +115,12 @@ describe("permissions", () => {
             command: "package",
         });
         // There should be no "s3:*" permissions added
-        expect(
-            get(cfTemplate.Resources.IamRoleLambdaExecution, "Properties.Policies[0].PolicyDocument.Statement")
-        ).toMatchObject([
-            {
-                Action: ["logs:CreateLogStream", "logs:CreateLogGroup"],
-            },
-            {
-                Action: ["logs:PutLogEvents"],
-            },
-        ]);
+        const statements = get(
+            cfTemplate.Resources.IamRoleLambdaExecution,
+            "Properties.Policies[0].PolicyDocument.Statement"
+        ) as unknown as { Action: string[] }[];
+        statements.forEach(({ Action }) => {
+            expect(Action).not.toEqual(expect.arrayContaining([expect.stringMatching(/^s3:.*$/)]));
+        });
     });
 });


### PR DESCRIPTION
Serverless v3.28.0 updates permissions given to lambda to be able to use a new logs:TagResource action on Cloudwatch groups. Rewriting the test to ensure no permission regarding s3 are added to lambda instead of checking exact Action match assertions, in order to have tests passing both for serverless v2 and latest v3

PR made on Serverless v3.28.0 that introduce this change : https://github.com/serverless/serverless/pull/11766

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->
