### PR TITLE
Add webp and avif exceptions to CF request function

### DIFF
--- a/src/constructs/aws/SinglePageApp.ts
+++ b/src/constructs/aws/SinglePageApp.ts
@@ -43,9 +43,9 @@ export class SinglePageApp extends StaticWebsiteAbstract {
          * let static files pass.
          *
          * Files extensions list taken from: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa
-         * Add pdf, xml and webmanifest as well
+         * Add pdf, xml, webmanifest and avif as well
          */
-        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest)$)([^.]+$)/;
+        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
 
 function handler(event) {
     var uri = event.request.uri;

--- a/src/constructs/aws/SinglePageApp.ts
+++ b/src/constructs/aws/SinglePageApp.ts
@@ -45,7 +45,7 @@ export class SinglePageApp extends StaticWebsiteAbstract {
          * Files extensions list taken from: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa
          * Add pdf, xml, webmanifest and avif as well
          */
-        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
+        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
 
 function handler(event) {
     var uri = event.request.uri;

--- a/test/unit/singlePageApp.test.ts
+++ b/test/unit/singlePageApp.test.ts
@@ -29,7 +29,7 @@ describe("single page app", () => {
             Object {
               "Properties": Object {
                 "AutoPublish": true,
-                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
+                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;
@@ -99,7 +99,7 @@ describe("single page app", () => {
         });
         const requestFunction = computeLogicalId("landing", "RequestFunction");
         expect(cfTemplate.Resources[requestFunction].Properties.FunctionCode).toMatchInlineSnapshot(`
-            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
+            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;

--- a/test/unit/singlePageApp.test.ts
+++ b/test/unit/singlePageApp.test.ts
@@ -29,7 +29,7 @@ describe("single page app", () => {
             Object {
               "Properties": Object {
                 "AutoPublish": true,
-                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest)$)([^.]+$)/;
+                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;
@@ -99,7 +99,7 @@ describe("single page app", () => {
         });
         const requestFunction = computeLogicalId("landing", "RequestFunction");
         expect(cfTemplate.Resources[requestFunction].Properties.FunctionCode).toMatchInlineSnapshot(`
-            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest)$)([^.]+$)/;
+            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|xml|pdf|webmanifest|webp|avif)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;


### PR DESCRIPTION
Hi,

AWS has updated their list of extensions excluded from redirections in SPA, this PR updates the list to match AWS' (adding the webp extension) and also adds the avif extension.

This allows developers using lift's SPA construct to use .webp and .avif images. Currently it will redirect to /index.html and not display the image.

See: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa