### PR TITLE
Fixed indentation on queue constrcut maxConcurrency example

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -368,7 +368,7 @@ It is possible to set the batch size between 1 and 10.
 constructs:
     my-queue:
         # ...
-    maxConcurrency: 10 # The maximum number of concurrent function instances that the SQS event source can invoke is 10 
+        maxConcurrency: 10 # The maximum number of concurrent function instances that the SQS event source can invoke is 10 
 ```
 
 The launch of maximum concurrency for SQS as an event source allows you to control Lambda function concurrency per source. You set the maximum concurrency on the event source mapping, not on the Lambda function.


### PR DESCRIPTION
In the documentation regarding the queue construct, the wrong level of indentation is used for the maxConcurrency example.