### PR TITLE
Fix getlift/lift#208, allow for batchSize above 10

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -360,7 +360,8 @@ By default, Lift configures Lambda to be invoked with 1 messages at a time. The 
 
 Note you can use [partial batch failures](#partial-batch-failures) to avoid failing the whole batch.
 
-It is possible to set the batch size between 1 and 10.
+It is possible to set the batch size between 1 and 10 for FIFO queues and 10000 for regular queues.
+For batch size over 10, [maxBatchingWindow](#maximum-batching-window) must be set.
 
 ### Max Concurrency
 

--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -43,7 +43,7 @@ const QUEUE_DEFINITION = {
         batchSize: {
             type: "number",
             minimum: 1,
-            maximum: 10,
+            maximum: 10000,
         },
         maxBatchingWindow: {
             type: "number",
@@ -165,6 +165,23 @@ export class Queue extends AwsConstruct {
             }
 
             delay = Duration.seconds(configuration.delay);
+        }
+
+        if (configuration.batchSize !== undefined) {
+            if (configuration.batchSize > 10 && configuration.fifo === true) {
+                throw new ServerlessError(
+                    `Invalid configuration in 'constructs.${this.id}': 'batchSize' must be between 0 and 10 for FIFO queues, '${configuration.batchSize}' given.`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
+            if (configuration.batchSize > 10 && !this.getMaximumBatchingWindow()) {
+                throw new ServerlessError(
+                    `Invalid configuration in 'constructs.${
+                        this.id
+                    }': 'maxBatchingWindow' must be greater than 0 for batchSize > 10, '${this.getMaximumBatchingWindow()}' given.`,
+                    "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+                );
+            }
         }
 
         let encryption = undefined;

--- a/test/unit/queues.test.ts
+++ b/test/unit/queues.test.ts
@@ -700,4 +700,53 @@ describe("queues", () => {
             );
         }
     });
+
+    it("should throw if batch size is over 10 for FIFO queues", async () => {
+        expect.assertions(2);
+
+        try {
+            await runServerless({
+                fixture: "queues",
+                configExt: merge({}, pluginConfigExt, {
+                    constructs: {
+                        emails: {
+                            batchSize: 100,
+                            fifo: true,
+                        },
+                    },
+                }),
+                command: "package",
+            });
+        } catch (error) {
+            expect(error).toBeInstanceOf(ServerlessError);
+            expect(error).toHaveProperty(
+                "message",
+                "Invalid configuration in 'constructs.emails': 'batchSize' must be between 0 and 10 for FIFO queues, '100' given."
+            );
+        }
+    });
+
+    it("should throw if batch size is over 10 and maxBatchWindow is not set", async () => {
+        expect.assertions(2);
+
+        try {
+            await runServerless({
+                fixture: "queues",
+                configExt: merge({}, pluginConfigExt, {
+                    constructs: {
+                        emails: {
+                            batchSize: 100,
+                        },
+                    },
+                }),
+                command: "package",
+            });
+        } catch (error) {
+            expect(error).toBeInstanceOf(ServerlessError);
+            expect(error).toHaveProperty(
+                "message",
+                "Invalid configuration in 'constructs.emails': 'maxBatchingWindow' must be greater than 0 for batchSize > 10, '0' given."
+            );
+        }
+    });
 });


### PR DESCRIPTION
AWS allows for batchSize up to 10k for non-FIFO queues where you have also set a maxBatchWindow.