### PR TITLE
Gracefully handle redirectToMainDomain with only a single domain

### DIFF
--- a/src/classes/cloudfrontFunctions.ts
+++ b/src/classes/cloudfrontFunctions.ts
@@ -2,10 +2,7 @@ import ServerlessError from "../utils/error";
 
 export function redirectToMainDomain(domains: string[] | undefined): string {
     if (domains === undefined || domains.length < 2) {
-        throw new ServerlessError(
-            `Invalid value in 'redirectToMainDomain': you must have at least 2 domains configured to enable redirection to the main domain.`,
-            "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
-        );
+        return "";
     }
 
     const mainDomain = domains[0];


### PR DESCRIPTION
We've run into issues with dynamic configs which are stage-dependent - different stages have different domain(s).

This change allows the directive to be present but will silence its behaviour where only a single domain has been specified.