### PR TITLE
Enable HTTP/3 support on CloudFront

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -153,8 +153,8 @@ export class ServerSideWebsite extends AwsConstruct {
             // All the assets paths are created in there
             additionalBehaviors: this.createCacheBehaviors(this.bucket),
             errorResponses: this.createErrorResponses(),
-            // Enable http2 transfer for better performances
-            httpVersion: HttpVersion.HTTP2,
+            // Enable http2 & http3 transfer for better performances
+            httpVersion: HttpVersion.HTTP2_AND_3,
             certificate: certificate,
             domainNames: this.domains,
         });

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -108,7 +108,7 @@ describe("server-side website", () => {
                         },
                     ],
                     Enabled: true,
-                    HttpVersion: "http2",
+                    HttpVersion: "http2and3",
                     IPV6Enabled: true,
                     Origins: [
                         {
@@ -214,7 +214,7 @@ describe("server-side website", () => {
                         ],
                     },
                     Enabled: true,
-                    HttpVersion: "http2",
+                    HttpVersion: "http2and3",
                     IPV6Enabled: true,
                     Origins: [
                         {


### PR DESCRIPTION
Update the `server-side-website` construct to include support for HTTP/3