### PR TITLE
Add wasm to redirect regex getlift/lift#331

### DIFF
--- a/src/constructs/aws/SinglePageApp.ts
+++ b/src/constructs/aws/SinglePageApp.ts
@@ -43,7 +43,7 @@ export class SinglePageApp extends StaticWebsiteAbstract {
          * let static files pass.
          *
          * Files extensions list taken from: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa
-         * Add pdf, xml, webmanifest and avif as well
+         * Add pdf, xml, webmanifest, avif and wasm as well
          */
         const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif|wasm)$)([^.]+$)/;
 

--- a/src/constructs/aws/SinglePageApp.ts
+++ b/src/constructs/aws/SinglePageApp.ts
@@ -45,7 +45,7 @@ export class SinglePageApp extends StaticWebsiteAbstract {
          * Files extensions list taken from: https://docs.aws.amazon.com/amplify/latest/userguide/redirects.html#redirects-for-single-page-web-apps-spa
          * Add pdf, xml, webmanifest and avif as well
          */
-        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
+        const code = `var REDIRECT_REGEX = /^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif|wasm)$)([^.]+$)/;
 
 function handler(event) {
     var uri = event.request.uri;

--- a/test/unit/singlePageApp.test.ts
+++ b/test/unit/singlePageApp.test.ts
@@ -29,7 +29,7 @@ describe("single page app", () => {
             Object {
               "Properties": Object {
                 "AutoPublish": true,
-                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
+                "FunctionCode": "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif|wasm)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;
@@ -99,7 +99,7 @@ describe("single page app", () => {
         });
         const requestFunction = computeLogicalId("landing", "RequestFunction");
         expect(cfTemplate.Resources[requestFunction].Properties.FunctionCode).toMatchInlineSnapshot(`
-            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif)$)([^.]+$)/;
+            "var REDIRECT_REGEX = /^[^.]+$|\\\\.(?!(css|gif|ico|jpg|jpeg|js|png|txt|svg|woff|woff2|ttf|map|json|webp|xml|pdf|webmanifest|avif|wasm)$)([^.]+$)/;
 
             function handler(event) {
                 var uri = event.request.uri;


### PR DESCRIPTION
https://github.com/getlift/lift/issues/331

Currently wasm files are not loaded properly as the CloudFront function redirects them to .html. Adding wasm to redirect regex fixes this and wasm files are loaded properly.
