### PR TITLE
Fix the `constructs` dependency to a Node 14-compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chalk": "^4.1.1",
     "change-case": "^4.1.2",
     "cidr-split": "^0.1.2",
-    "constructs": "^10.0.127",
+    "constructs": "10.2.20",
     "inquirer": "^7.3.3",
     "js-yaml": "^3.14.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
The `constructs` package dropped support for Node 14.

Until we do the same, we need to require a version compatible with Node 14.