### PR TITLE
Allow the usage under Node 20.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ jobs:
                     - 14
                     - 16
                     - 18
+                    - 20
                 serverless:
                     - "2.36.0"
                     - "2"
                     - "latest"
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node }}
             - uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.3.4"
   },
   "engines": {
-    "node": ">=14.15.0 <20"
+    "node": ">=14.15.0 <21"
   },
   "files": [
     "/dist"


### PR DESCRIPTION
Allow the usage under Node 20.

The CI worked here:
https://github.com/dnp1/lift/actions/runs/5155713648

