### PR TITLE
SQS DLQ alarm should treat missing data as not breaching

### DIFF
--- a/src/constructs/aws/Queue.ts
+++ b/src/constructs/aws/Queue.ts
@@ -3,7 +3,7 @@ import type { CfnQueue } from "aws-cdk-lib/aws-sqs";
 import { Queue as CdkQueue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
 import type { FromSchema } from "json-schema-to-ts";
 import type { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
-import { Alarm, ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { Subscription, SubscriptionProtocol, Topic } from "aws-cdk-lib/aws-sns";
 import type { AlarmActionConfig } from "aws-cdk-lib/aws-cloudwatch/lib/alarm-action";
 import type { Construct as CdkConstruct } from "constructs";
@@ -241,6 +241,7 @@ export class Queue extends AwsConstruct {
                 // Alert as soon as we have 1 message in the DLQ
                 threshold: 0,
                 comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+                treatMissingData: TreatMissingData.NOT_BREACHING,
             });
             this.alarm.addAlarmAction({
                 bind(): AlarmActionConfig {

--- a/test/unit/queues.test.ts
+++ b/test/unit/queues.test.ts
@@ -411,6 +411,7 @@ describe("queues", () => {
                 Period: 60,
                 Statistic: "Sum",
                 Threshold: 0,
+                TreatMissingData: "notBreaching",
             },
         });
         expect(cfTemplate.Resources[computeLogicalId("emails", "AlarmTopic")]).toMatchObject({


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-monitoring-using-cloudwatch.html

> When an Amazon SQS queue is inactive for more than six hours, the Amazon SQS service is considered asleep and stops delivering metrics to the CloudWatch service. Missing data, or data representing zero, can't be visualized in the CloudWatch metrics for Amazon SQS for the time period that your Amazon SQS queue was inactive.

Because of this, the DLQ alarms currently created by lift will show `Insufficient data` most of the time when the queue they monitor are empty _and inactive_.

![dlq cw alarms](https://github.com/getlift/lift/assets/2000389/4b270887-53e0-4021-a4f0-5be9921ea4e9)

This PR sets `treatMissingData` to `notBreaching` on the alarm vs the current CDK default of `missing`. `notBreaching` will allow an inactive (and thus empty) SQS queue to show `Ok` when browsing alarms.
