### PR TITLE
fix: adds `dynamodb:ConditionCheckItem` permission to dynamodb construct

### DIFF
--- a/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
+++ b/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
@@ -86,6 +86,7 @@ export class DatabaseDynamoDBSingleTable extends AwsConstruct {
                     "dynamodb:DeleteItem",
                     "dynamodb:BatchWriteItem",
                     "dynamodb:UpdateItem",
+                    "dynamodb:ConditionCheckItem",
                 ],
                 [this.table.tableArn, Stack.of(this).resolve(Fn.join("/", [this.table.tableArn, "index", "*"]))]
             ),


### PR DESCRIPTION
Closes #339 

Without this IAM permission, transacted writes in dynamodb using the `ConditionCheck` feature are disallowed.

See:

https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ConditionCheck.html

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis-iam.html

Example usage:

After this change you would be able to make use of ConditionCheck in transacted writes e.g.

```ts
client.send(
  new TransactWriteCommand({
    TransactItems: [
      // checks an item condition is successful
      {
        ConditionCheck: {
          TableName: environment.tableName,
          Key: {
            PK: 'somepk',
            SK: 'somesk',
          },
          ConditionExpression: 'attribute_exists(PK)',
        },
      },
      // and writes a record in 1 transaction ensuring consistency
      {
        Put: {
          TableName: environment.tableName,
          Item: someItem,
        },
      }
    ]
  }));
```
