### PR TITLE
Add in method setting for webhooks

### DIFF
--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -20,6 +20,7 @@ constructs:
         authorizer:
             handler: myAuthorizer.main
         path: /my-webhook-endpoint
+        method: POST
 
 plugins:
     - serverless-lift
@@ -161,6 +162,23 @@ constructs:
 ```
 
 Always favor dynamic path selector to ensure the minimum amount of compute is executed downstream. The list of available dynamic selector is available in [API Gateway documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html#http-api-develop-integrations-aws-services-parameter-mapping).
+
+### Method
+
+_Optional_
+Defaults to `POST`
+
+This is the HTTP method the webhook will accept. It can be any of the following:
+- `POST`
+- `PUT`
+- `PATCH`
+
+```yaml
+constructs:
+    stripe:
+        # ...
+        method: POST
+```
 
 ## Extensions
 

--- a/src/constructs/aws/Webhook.ts
+++ b/src/constructs/aws/Webhook.ts
@@ -28,7 +28,7 @@ const WEBHOOK_DEFINITION = {
         insecure: { type: "boolean" },
         path: { type: "string" },
         eventType: { type: "string" },
-        method: { type: "string" },
+        method: { enum: ["POST", "PUT", "PATCH"] },
     },
     required: ["path"],
     additionalProperties: false,

--- a/src/constructs/aws/Webhook.ts
+++ b/src/constructs/aws/Webhook.ts
@@ -28,12 +28,14 @@ const WEBHOOK_DEFINITION = {
         insecure: { type: "boolean" },
         path: { type: "string" },
         eventType: { type: "string" },
+        method: { type: "string" },
     },
     required: ["path"],
     additionalProperties: false,
 } as const;
 const WEBHOOK_DEFAULTS = {
     insecure: false,
+    method: "POST",
 };
 
 type Configuration = FromSchema<typeof WEBHOOK_DEFINITION>;
@@ -46,6 +48,7 @@ export class Webhook extends AwsConstruct {
     private readonly bus: EventBus;
     private readonly apiEndpointOutput: CfnOutput;
     private readonly endpointPathOutput: CfnOutput;
+    private readonly method: string;
 
     constructor(
         scope: CdkConstruct,
@@ -108,9 +111,10 @@ export class Webhook extends AwsConstruct {
                 EventBusName: this.bus.eventBusName,
             },
         });
+        this.method = resolvedConfiguration.method;
         const route = new CfnRoute(this, "Route", {
             apiId: this.api.apiId,
-            routeKey: `POST ${resolvedConfiguration.path}`,
+            routeKey: `${this.method} ${resolvedConfiguration.path}`,
             target: Fn.join("/", ["integrations", eventBridgeIntegration.ref]),
             authorizationType: "NONE",
         });

--- a/test/fixtures/webhooks/serverless.yml
+++ b/test/fixtures/webhooks/serverless.yml
@@ -24,3 +24,21 @@ constructs:
             bus:
                 Properties:
                     Name: myBus
+    post:
+        type: webhook
+        authorizer:
+            handler: authorizer.main
+        path: /post
+        method: POST
+    put:
+        type: webhook
+        authorizer:
+            handler: authorizer.main
+        path: /put
+        method: PUT
+    patch:
+        type: webhook
+        authorizer:
+            handler: authorizer.main
+        path: /patch
+        method: PATCH

--- a/test/unit/webhooks.test.ts
+++ b/test/unit/webhooks.test.ts
@@ -21,6 +21,16 @@ describe("webhooks", () => {
         });
     });
 
+    test.each([
+        ["post", "POST"],
+        ["put", "PUT"],
+        ["patch", "PATCH"],
+    ])("%p webhook should have method %p", (useCase, expectedMethod) => {
+        expect(cfTemplate.Resources[computeLogicalId(useCase, "Route")]["Properties"]).toMatchObject({
+            RouteKey: expectedMethod + " /" + expectedMethod.toLowerCase(),
+        });
+    });
+
     it("allows overriding webhook properties", () => {
         expect(cfTemplate.Resources[computeLogicalId("extendedWebhook", "Bus")].Properties).toMatchObject({
             Name: "myBus",


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.

If you are adding a new config option in a component, please explain the use case with an example.
-->
Some webhooks utilise PUT instead of strictly POST, in order to support them I've added in the ability to specify which method the webhook should allow in order to allow for these cases

Let me know if you want any changes to this, it's my first time touching the project so suggestions are more than welcome