### PR TITLE
When we have custom domain(s), always redirect to them

### DIFF
--- a/src/classes/cloudfrontFunctions.ts
+++ b/src/classes/cloudfrontFunctions.ts
@@ -1,7 +1,8 @@
 import ServerlessError from "../utils/error";
 
 export function redirectToMainDomain(domains: string[] | undefined): string {
-    if (domains === undefined || domains.length < 2) {
+    if (domains === undefined) {
+        // No custom domains specified
         return "";
     }
 


### PR DESCRIPTION
This ensures API Gateway and Cloudfront URLs all redirect to the primary domain - this helps prevent duplicating sites and getting them indexed across multiple hosts accidentally