### PR TITLE
Add option to name GSI properties and support string/number types

### DIFF
--- a/docs/database-dynamodb-single-table.md
+++ b/docs/database-dynamodb-single-table.md
@@ -98,6 +98,21 @@ GSI created on the table follow generic names principles:
 
 The first time you deploy your construct using `serverless deploy`, you can specify any amount of GSI between `1` and `20`. On subsequent deploys, any modification made to an already deployed construct cannot add or remove more than 1 GSI at a time. If you need 2 additional GSI after initial deployment of the exemple above, you must first update the `gsiCount` to `4`, deploy, and then finally update it to the final desired quantity of `5`.
 
+#### Global secondary index naming and types
+
+Global secondary indexes are created following [Global secondary indexes principles](#global-secondary-indexes) outlined above. If you need to deviate from the standard naming convention and types you can specify the settings for each GSI as follows:
+
+```yaml
+constructs:
+    myTable:
+        # ...
+        gsiCount: 1
+        gsis:
+            - index: GSI-1-SK
+              name: mySecondaryIndex1Sort # override the default naming
+              type: number # make the sort key numeric
+```
+
 ### Local secondary indexes
 
 Each DynamoDB table can includes up to 5 local secondary indexes. You can deploy a table with those 5 indexes using the `localSecondaryIndexes` property.

--- a/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
+++ b/src/constructs/aws/DatabaseDynamoDBSingleTable.ts
@@ -14,6 +14,62 @@ const DATABASE_DEFINITION = {
         type: { const: "database/dynamodb-single-table" },
         localSecondaryIndexes: { type: "boolean" },
         gsiCount: { type: "integer", minimum: 1, maximum: 20 },
+        gsis: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    index: {
+                        enum: [
+                            "GSI-1-PK",
+                            "GSI-2-PK",
+                            "GSI-3-PK",
+                            "GSI-4-PK",
+                            "GSI-5-PK",
+                            "GSI-6-PK",
+                            "GSI-7-PK",
+                            "GSI-8-PK",
+                            "GSI-9-PK",
+                            "GSI-10-PK",
+                            "GSI-11-PK",
+                            "GSI-12-PK",
+                            "GSI-13-PK",
+                            "GSI-14-PK",
+                            "GSI-15-PK",
+                            "GSI-16-PK",
+                            "GSI-17-PK",
+                            "GSI-18-PK",
+                            "GSI-19-PK",
+                            "GSI-20-PK",
+                            "GSI-1-SK",
+                            "GSI-2-SK",
+                            "GSI-3-SK",
+                            "GSI-4-SK",
+                            "GSI-5-SK",
+                            "GSI-6-SK",
+                            "GSI-7-SK",
+                            "GSI-8-SK",
+                            "GSI-9-SK",
+                            "GSI-10-SK",
+                            "GSI-11-SK",
+                            "GSI-12-SK",
+                            "GSI-13-SK",
+                            "GSI-14-SK",
+                            "GSI-15-SK",
+                            "GSI-16-SK",
+                            "GSI-17-SK",
+                            "GSI-18-SK",
+                            "GSI-19-SK",
+                            "GSI-20-SK",
+                        ],
+                    },
+                    name: { type: "string" },
+                    type: { enum: ["string", "number"] },
+                },
+                required: ["index"],
+                additionalProperties: false,
+            },
+        },
     },
     additionalProperties: false,
 } as const;
@@ -23,6 +79,7 @@ const DATABASE_DEFAULTS: Required<Configuration> = {
     type: "database/dynamodb-single-table",
     localSecondaryIndexes: false,
     gsiCount: 0,
+    gsis: [],
 };
 
 export class DatabaseDynamoDBSingleTable extends AwsConstruct {
@@ -61,10 +118,21 @@ export class DatabaseDynamoDBSingleTable extends AwsConstruct {
                 globalSecondaryIndex <= resolvedConfiguration.gsiCount;
                 globalSecondaryIndex++
             ) {
+                const partitionKey = `GSI-${globalSecondaryIndex}-PK`;
+                const partitionKeyMetadata = resolvedConfiguration.gsis.find((gsi) => gsi.index === partitionKey);
+                const sortKey = `GSI-${globalSecondaryIndex}-SK`;
+                const sortKeyMetadata = resolvedConfiguration.gsis.find((gsi) => gsi.index === sortKey);
+
                 this.table.addGlobalSecondaryIndex({
                     indexName: `GSI-${globalSecondaryIndex}`,
-                    partitionKey: { name: `GSI-${globalSecondaryIndex}-PK`, type: AttributeType.STRING },
-                    sortKey: { name: `GSI-${globalSecondaryIndex}-SK`, type: AttributeType.STRING },
+                    partitionKey: {
+                        name: partitionKeyMetadata?.name ?? partitionKey,
+                        type: partitionKeyMetadata?.type === "number" ? AttributeType.NUMBER : AttributeType.STRING,
+                    },
+                    sortKey: {
+                        name: sortKeyMetadata?.name ?? sortKey,
+                        type: sortKeyMetadata?.type === "number" ? AttributeType.NUMBER : AttributeType.STRING,
+                    },
                 });
             }
         }

--- a/test/fixtures/databasesDynamoDBSingleTable/serverless.yml
+++ b/test/fixtures/databasesDynamoDBSingleTable/serverless.yml
@@ -13,6 +13,22 @@ constructs:
     databaseWithGlobalSecondaryIndexes:
         type: database/dynamodb-single-table
         gsiCount: 2
+    databaseWithRenamedIndexes:
+        type: database/dynamodb-single-table
+        gsiCount: 1
+        gsis:
+            - index: GSI-1-PK
+              name: CustomPK1
+            - index: GSI-1-SK
+              name: CustomSK1
+    databaseWithNumberTypeIndexes:
+        type: database/dynamodb-single-table
+        gsiCount: 1
+        gsis:
+            - index: GSI-1-PK
+              type: number
+            - index: GSI-1-SK
+              type: number
     extendedDatabase:
         type: database/dynamodb-single-table
         extensions:

--- a/test/unit/databasesDynamoDBSingleTable.test.ts
+++ b/test/unit/databasesDynamoDBSingleTable.test.ts
@@ -111,6 +111,66 @@ describe("databasesDynamoDBSingleTable", () => {
         );
     });
 
+    it("should use custom names for GSI", () => {
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithRenamedIndexes", "Table")].Properties
+                .AttributeDefinitions
+        ).toContainEqual({ AttributeName: `CustomPK1`, AttributeType: "S" });
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithRenamedIndexes", "Table")].Properties
+                .AttributeDefinitions
+        ).toContainEqual({ AttributeName: `CustomSK1`, AttributeType: "S" });
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithRenamedIndexes", "Table")].Properties
+                .GlobalSecondaryIndexes
+        ).toEqual([
+            {
+                IndexName: `GSI-1`,
+                KeySchema: [
+                    {
+                        AttributeName: `CustomPK1`,
+                        KeyType: "HASH",
+                    },
+                    {
+                        AttributeName: `CustomSK1`,
+                        KeyType: "RANGE",
+                    },
+                ],
+                Projection: { ProjectionType: "ALL" },
+            },
+        ]);
+    });
+
+    it("should use number types for GSI", () => {
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithNumberTypeIndexes", "Table")].Properties
+                .AttributeDefinitions
+        ).toContainEqual({ AttributeName: `GSI-1-PK`, AttributeType: "N" });
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithNumberTypeIndexes", "Table")].Properties
+                .AttributeDefinitions
+        ).toContainEqual({ AttributeName: `GSI-1-SK`, AttributeType: "N" });
+        expect(
+            cfTemplate.Resources[computeLogicalId("databaseWithNumberTypeIndexes", "Table")].Properties
+                .GlobalSecondaryIndexes
+        ).toEqual([
+            {
+                IndexName: `GSI-1`,
+                KeySchema: [
+                    {
+                        AttributeName: `GSI-1-PK`,
+                        KeyType: "HASH",
+                    },
+                    {
+                        AttributeName: `GSI-1-SK`,
+                        KeyType: "RANGE",
+                    },
+                ],
+                Projection: { ProjectionType: "ALL" },
+            },
+        ]);
+    });
+
     it("allows overriding table properties", () => {
         expect(cfTemplate.Resources[computeLogicalId("extendedDatabase", "Table")].Properties).toMatchObject({
             TableClass: "STANDARD_INFREQUENT_ACCESS",


### PR DESCRIPTION
This PR adds support for configuring the GSI properties (if necessary) in a controlled way.

Two use cases I have are:

1. supporting well named keys as per standards according to wider dev team (not my choice), it also tackles the discussion here: #76 about fine grained control of the keys

2. I need to support numeric GSI's, this is because I want to use update expressions to do `ADD/SUBTRACT` without having to read out the record, then perform a round trip (and potential race condition) for subsequent writes.

If this PR goes against any sort of standards for property definitions but you like it then just let me know what I need to do to improve this please. Duplicating the GSI-X-YY multiple times for the enum looks dirty, would be happy to just make that "string" but considered that it can be correctly schema'd so left it in.