### PR TITLE
Add distribution id to server side website

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -177,6 +177,26 @@ resources:
                 # ...
 ```
 
+- `distributionId`: the Cloudfront Distribution Id
+
+This can be used to configure a Cloudfront Invalidation Policy
+
+```yaml
+constructs:
+    website:
+        type: server-side-website
+        # ...
+iam:
+  role:
+    statements:
+        - Effect: Allow
+          Action:
+            - 'cloudfront:CreateInvalidation'
+          Resource:
+            - 'arn:aws:cloudfront::${aws:accountId}:distribution/${construct:website.distributionId}'
+          # ...
+```
+
 ## Commands
 
 `serverless deploy` deploys everything configured in `serverless.yml` and uploads assets.

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -187,6 +187,7 @@ export class ServerSideWebsite extends AwsConstruct {
         return {
             url: () => this.getUrl(),
             cname: () => this.getCName(),
+            distributionId: () => this.getDistributionId(),
         };
     }
 


### PR DESCRIPTION
Output the Cloudfront Distribution Id so can be used for IAM policies