### PR TITLE
fix: hide stage in URL in REST scenario

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -129,7 +129,7 @@ export class ServerSideWebsite extends AwsConstruct {
                 : undefined;
 
         // Hide the stage in the URL in REST scenario
-        const originPath = configuration.apiGateway === "rest" ? "/" + provider.getStage() : undefined;
+        const originPath = configuration.apiGateway === "rest" ? "/" + (provider.getStage() ?? "") : undefined;
 
         this.distribution = new Distribution(this, "CDN", {
             comment: `${provider.stackName} ${id} website CDN`,

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -129,7 +129,7 @@ export class ServerSideWebsite extends AwsConstruct {
                 : undefined;
 
         // Hide the stage in the URL in REST scenario
-        const originPath = configuration.apiGateway === "rest" ? "/" + provider.serverless.service.provider.stage : undefined
+        const originPath = configuration.apiGateway === "rest" ? "/" + provider.getStage() : undefined;
 
         this.distribution = new Distribution(this, "CDN", {
             comment: `${provider.stackName} ${id} website CDN`,

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -128,6 +128,9 @@ export class ServerSideWebsite extends AwsConstruct {
                 ? acm.Certificate.fromCertificateArn(this, "Certificate", configuration.certificate)
                 : undefined;
 
+        // Hide the stage in the URL in REST scenario
+        const originPath = configuration.apiGateway === "rest" ? "/" + provider.serverless.service.provider.stage : undefined
+
         this.distribution = new Distribution(this, "CDN", {
             comment: `${provider.stackName} ${id} website CDN`,
             defaultBehavior: {
@@ -135,6 +138,7 @@ export class ServerSideWebsite extends AwsConstruct {
                 origin: new HttpOrigin(apiGatewayDomain, {
                     // API Gateway only supports HTTPS
                     protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
+                    originPath,
                 }),
                 // For a backend app we all all methods
                 allowedMethods: AllowedMethods.ALLOW_ALL,

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -146,7 +146,7 @@ export class AwsProvider implements ProviderInterface {
      *
      * @internal
      */
-    getStage(): string {
+    getStage(): string | undefined {
         return this.serverless.service.provider.stage;
     }
 

--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -142,6 +142,15 @@ export class AwsProvider implements ProviderInterface {
     }
 
     /**
+     * Returns name of the stage.
+     *
+     * @internal
+     */
+    getStage(): string {
+        return this.serverless.service.provider.stage;
+    }
+
+    /**
      * Resolves the value of a CloudFormation stack output.
      */
     async getStackOutput(output: CfnOutput): Promise<string | undefined> {

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -260,6 +260,7 @@ describe("server-side website", () => {
                                     [{ Ref: "ApiGatewayRestApi" }, "execute-api.us-east-1.amazonaws.com"],
                                 ],
                             },
+                            OriginPath: "/dev",
                         },
                     ],
                 },


### PR DESCRIPTION
This PR attempts to solve https://github.com/getlift/lift/issues/364. The issue is that the stage needs to be appended to the URL in REST scenario in order to view the deployed app. By using [`originPath`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-origin.html#:~:text=%3A%20No%20interruption-,OriginPath,Update%20requires%3A%20No%20interruption,-OriginShield) of the CloudFront distribution we can hide it from the user so he can simply access the CloudFront URL/custom domain.

This is my first time working on a serverless plugin so I hope I used the correct approach. Please me know if I should change anything.