### PR TITLE
Use lambda url as cloudfront origin if functionName is defined

### DIFF
--- a/src/providers/AwsProvider.ts
+++ b/src/providers/AwsProvider.ts
@@ -62,6 +62,7 @@ export class AwsProvider implements ProviderInterface {
     public naming: {
         getStackName: () => string;
         getLambdaLogicalId: (functionName: string) => string;
+        getLambdaFunctionUrlLogicalId: (functionName: string) => string;
         getRestApiLogicalId: () => string;
         getHttpApiLogicalId: () => string;
     };

--- a/src/types/serverless.ts
+++ b/src/types/serverless.ts
@@ -24,6 +24,7 @@ export type Provider = {
     naming: {
         getStackName: () => string;
         getLambdaLogicalId: (functionName: string) => string;
+        getLambdaFunctionUrlLogicalId: (functionName: string) => string;
         getRestApiLogicalId: () => string;
         getHttpApiLogicalId: () => string;
         getCompiledTemplateFileName: () => string;


### PR DESCRIPTION
This PR is a draft for using lambda URL as CloudFront origin domain

Simply remove `events` key from function and add `url: true`
Before:
`
functions:
    web:
        handler: public/index.php
        memorySize: 1769
        timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
        runtime: php-82-fpm
        events:
            - httpApi: '*'
`

After
`
functions:
    web:
        handler: public/index.php
        memorySize: 1769
        timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
        runtime: php-82-fpm
        url: true

constructs:
    website:
        type: server-side-website
        domain: ${param:domain}
        certificate: ${param:certificate}
        functionName: web
        assets:
            '/assets/*': public/assets
`