### PR TITLE
Add BlockPublicAccess required config

### DIFF
--- a/src/constructs/aws/StaticWebsite.ts
+++ b/src/constructs/aws/StaticWebsite.ts
@@ -3,6 +3,7 @@ import { FunctionEventType } from "aws-cdk-lib/aws-cloudfront";
 import type { Construct as CdkConstruct } from "constructs";
 import type { AwsProvider } from "@lift/providers";
 import type { BucketProps } from "aws-cdk-lib/aws-s3";
+import { BlockPublicAccess } from "aws-cdk-lib/aws-s3";
 import { RemovalPolicy } from "aws-cdk-lib";
 import { redirectToMainDomain } from "../../classes/cloudfrontFunctions";
 import { getCfnFunctionAssociations } from "../../utils/getDefaultCfnFunctionAssociations";
@@ -71,6 +72,12 @@ export class StaticWebsite extends StaticWebsiteAbstract {
             websiteErrorDocument: this.errorPath(),
             // public read access is required when enabling static website hosting
             publicReadAccess: true,
+            blockPublicAccess: new BlockPublicAccess({
+                blockPublicAcls: false,
+                blockPublicPolicy: false,
+                ignorePublicAcls: false,
+                restrictPublicBuckets: false,
+            }),
             // For a static website, the content is code that should be versioned elsewhere
             removalPolicy: RemovalPolicy.DESTROY,
         };


### PR DESCRIPTION
Fixes #320 

## Description

Since april 2023, AWS S3 enforces two new default bucket security settings by automatically enabling S3 Block Public Access and disabling S3 access control lists (ACLs) for all new S3 buckets

This hotfix adds missing required BlockPublicAccess configuration.

## How to Reproduce

Deploy this stack and error is thrown.

```yaml
service: demo

provider:
    name: aws
    region: eu-west-3
    stage: prod

plugins:
    - serverless-lift

constructs:
    demo:
        type: static-website
        path: dist
```

## Before

![Captura de pantalla 2024-02-20 a las 23 27 10](https://github.com/getlift/lift/assets/13980708/2124c4fb-16ed-4cc8-8c15-860090c7aea1)

## After

![image](https://github.com/getlift/lift/assets/13980708/034ba5d9-97c4-42d2-93c3-80d17fbf0b9a)
