### PR TITLE
ServerSideWebsite: Add Progress.create() arg for Serverless 4 compatibility

### DIFF
--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -239,7 +239,9 @@ export class ServerSideWebsite extends AwsConstruct {
         const progress = getUtils().progress;
         let uploadProgress: Progress | undefined;
         if (progress) {
-            uploadProgress = progress.create();
+            uploadProgress = progress.create({
+                message: 'Uploading assets'
+            });
         }
 
         let invalidate = false;


### PR DESCRIPTION
Hi there,

With the release of Serverless 4, it appears that the ServerlessUtils `progress.create()` method now requires an initial argument to be passed. This is causing issues during deployment and any other time the `uploadAssets()` function is called.

Steps to Reproduce:

- Use Lift's ServerSideWebsite with Serverless 4.
- Trigger deployment or any action that calls the `uploadAssets` function.
- Observe the error due to the missing argument for `progress.create()`.

Proposed Fix: Update the `uploadAssets()` function in ServerSideWebsite to pass an initial argument to `progress.create()` as follows:

```js
uploadProgress = progress.create({
      message: 'Uploading assets'
});
```

Current Code Reference:
https://github.com/getlift/lift/blob/08772c56cc219ca7fa65cc4ff7c4dfea20246a70/src/constructs/aws/ServerSideWebsite.ts#L242

Documentation:
https://www.serverless.com/framework/docs/guides/plugins/cli-output#interactive-progress

Solves serverless/serverless#12797

Cheers,
Noah
