### PR TITLE
Speed up S3 sync uploads

### DIFF
--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -21,7 +21,7 @@ const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);
 const readFile = util.promisify(fs.readFile);
 
-const S3_UPLOAD_CONCURRENCY = 32;
+const S3_UPLOAD_CONCURRENCY = 16;
 
 type S3Objects = Record<string, S3Object>;
 

--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -19,6 +19,9 @@ import { getUtils } from "./logger";
 
 const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);
+const readFile = util.promisify(fs.readFile);
+
+const S3_UPLOAD_CONCURRENCY = 32;
 
 type S3Objects = Record<string, S3Object>;
 
@@ -45,11 +48,11 @@ export async function s3Sync({
 
     // Upload files by chunks
     let skippedFiles = 0;
-    for (const batch of chunk(filesToUpload, 2)) {
+    for (const batch of chunk(filesToUpload, S3_UPLOAD_CONCURRENCY)) {
         await Promise.all(
             batch.map(async (file) => {
                 const targetKey = targetPathPrefix !== undefined ? path.posix.join(targetPathPrefix, file) : file;
-                const fileContent = fs.readFileSync(path.posix.join(localPath, file));
+                const fileContent = await readFile(path.posix.join(localPath, file));
 
                 // Check that the file isn't already uploaded
                 if (targetKey in existingS3Objects) {

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -540,25 +540,28 @@ describe("server-side website", () => {
 
         // scripts.js and styles.css were updated
         sinon.assert.callCount(putObjectSpy, 3);
-        expect(putObjectSpy.firstCall.firstArg).toEqual({
-            Bucket: "bucket-name",
-            Key: "assets/scripts.js",
-            Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/public/scripts.js")),
-            ContentType: "application/javascript",
-        });
-        expect(putObjectSpy.secondCall.firstArg).toEqual({
-            Bucket: "bucket-name",
-            Key: "assets/styles.css",
-            Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/public/styles.css")),
-            ContentType: "text/css",
-        });
-        // It should upload the custom error page
-        expect(putObjectSpy.thirdCall.firstArg).toEqual({
-            Bucket: "bucket-name",
-            Key: "error.html",
-            Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/error.html")),
-            ContentType: "text/html",
-        });
+        expect(putObjectSpy.getCalls().map((call) => call.firstArg as unknown)).toEqual(
+            expect.arrayContaining([
+                {
+                    Bucket: "bucket-name",
+                    Key: "assets/scripts.js",
+                    Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/public/scripts.js")),
+                    ContentType: "application/javascript",
+                },
+                {
+                    Bucket: "bucket-name",
+                    Key: "assets/styles.css",
+                    Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/public/styles.css")),
+                    ContentType: "text/css",
+                },
+                {
+                    Bucket: "bucket-name",
+                    Key: "error.html",
+                    Body: fs.readFileSync(path.join(__dirname, "../fixtures/serverSideWebsite/error.html")),
+                    ContentType: "text/html",
+                },
+            ])
+        );
         // image.jpg was deleted
         sinon.assert.calledOnce(deleteObjectsSpy);
         expect(deleteObjectsSpy.firstCall.firstArg).toEqual({

--- a/test/unit/staticWebsite.test.ts
+++ b/test/unit/staticWebsite.test.ts
@@ -553,18 +553,22 @@ describe("static websites", () => {
 
         // scripts.js and styles.css were updated
         sinon.assert.callCount(putObjectSpy, 2);
-        expect(putObjectSpy.firstCall.firstArg).toEqual({
-            Bucket: "bucket-name",
-            Key: "scripts.js",
-            Body: fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/scripts.js")),
-            ContentType: "application/javascript",
-        });
-        expect(putObjectSpy.secondCall.firstArg).toEqual({
-            Bucket: "bucket-name",
-            Key: "styles.css",
-            Body: fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/styles.css")),
-            ContentType: "text/css",
-        });
+        expect(putObjectSpy.getCalls().map((call) => call.firstArg as unknown)).toEqual(
+            expect.arrayContaining([
+                {
+                    Bucket: "bucket-name",
+                    Key: "scripts.js",
+                    Body: fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/scripts.js")),
+                    ContentType: "application/javascript",
+                },
+                {
+                    Bucket: "bucket-name",
+                    Key: "styles.css",
+                    Body: fs.readFileSync(path.join(__dirname, "../fixtures/staticWebsites/public/styles.css")),
+                    ContentType: "text/css",
+                },
+            ])
+        );
         // image.jpg was deleted
         sinon.assert.calledOnce(deleteObjectsSpy);
         expect(deleteObjectsSpy.firstCall.firstArg).toEqual({


### PR DESCRIPTION
- Increase S3 sync upload concurrency from 2 to 16 files per batch.
- Read files asynchronously during sync so small-asset deployments are less blocked by local file I/O.
