### PR TITLE
Support OSLS as a Serverless peer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
                     - 22
                     - 24
                 serverless:
-                    - "3"
+                    - package: "osls@>=3.54.1 <3.65.0"
+                      module: osls
+                    - package: "serverless@3"
+                      module: serverless
                     # - "4" Official way to test plugins for serverless is missing.
         steps:
             - uses: actions/checkout@v4
@@ -29,10 +32,11 @@ jobs:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/package.json') }}
             - run: npm i
-            - run: npm i serverless@${{ matrix.serverless }}
+            - run: npm i "${{ matrix.serverless.package }}"
             - name: Run jest unit tests
               env:
                   NODE_OPTIONS: "--max_old_space_size=4096"
+                  SERVERLESS_TEST_PACKAGE: ${{ matrix.serverless.module }}
               run: npm test
     lint:
         name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
                     - 22
                     - 24
                 serverless:
-                    - package: "osls@>=3.54.1 <3.65.0"
+                    - package: "osls@3"
                       module: osls
                     - package: "serverless@3"
                       module: serverless
@@ -32,7 +32,7 @@ jobs:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/package.json') }}
             - run: npm i
-            - run: npm i "${{ matrix.serverless.package }}"
+            - run: npm i --save-dev "${{ matrix.serverless.package }}"
             - name: Run jest unit tests
               env:
                   NODE_OPTIONS: "--max_old_space_size=4096"

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,8 @@ const { compilerOptions } = require("./tsconfig");
 module.exports = {
     moduleNameMapper: Object.assign(pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>" }), {
         axios: "axios/dist/node/axios.cjs",
+        filenamify: "<rootDir>/test/utils/filenamify.ts",
+        "https-proxy-agent": "<rootDir>/test/utils/httpsProxyAgent.ts",
     }),
     preset: "ts-jest",
     testPathIgnorePatterns: ["dist"],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "json-schema-to-ts": "^1.6.4",
     "lint-staged": "^11.0.0",
     "nodemon": "^3.1.11",
-    "osls": ">=3.54.1 <3.65.0",
+    "osls": "^3.72.0",
     "prettier": "^2.3.2",
     "sinon": "^11.1.1",
     "stdout-stderr": "^0.1.13",
@@ -57,7 +57,7 @@
     "typescript": "^4.3.4"
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=20.19.0"
   },
   "files": [
     "/dist"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/jest": "^27.0.1",
     "@types/js-yaml": "^3.12.5",
     "@types/json-schema": "^7.0.8",
+    "@types/lodash": "^4.17.24",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^10.17.28",
     "@types/sinon": "^10.0.2",
@@ -47,8 +48,8 @@
     "json-schema-to-ts": "^1.6.4",
     "lint-staged": "^11.0.0",
     "nodemon": "^3.1.11",
+    "osls": ">=3.54.1 <3.65.0",
     "prettier": "^2.3.2",
-    "serverless": "^3.40.0",
     "sinon": "^11.1.1",
     "stdout-stderr": "^0.1.13",
     "ts-jest": "^27.0.3",
@@ -82,6 +83,15 @@
   },
   "types": "dist/src/plugin.d.ts",
   "peerDependencies": {
+    "osls": "^3",
     "serverless": "^3 || ^4"
+  },
+  "peerDependenciesMeta": {
+    "osls": {
+      "optional": true
+    },
+    "serverless": {
+      "optional": true
+    }
   }
 }

--- a/test/utils/filenamify.ts
+++ b/test/utils/filenamify.ts
@@ -1,0 +1,9 @@
+const invalidCharacters = new Set(["<", ">", ":", '"', "/", "\\", "|", "?", "*"]);
+
+const filenamify = (filename: string): string =>
+    filename
+        .split("")
+        .map((character) => (invalidCharacters.has(character) || character.charCodeAt(0) < 32 ? "!" : character))
+        .join("");
+
+export default filenamify;

--- a/test/utils/httpsProxyAgent.ts
+++ b/test/utils/httpsProxyAgent.ts
@@ -1,0 +1,3 @@
+import https from "https";
+
+export class HttpsProxyAgent extends https.Agent {}

--- a/test/utils/runServerless.ts
+++ b/test/utils/runServerless.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { runInThisContext } from "vm";
 import { Names } from "aws-cdk-lib";
 import type originalRunServerless from "@serverless/test/run-serverless";
 import setupRunServerlessFixturesEngine from "@serverless/test/setup-run-serverless-fixtures-engine";
@@ -12,7 +13,27 @@ type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 type RunServerlessReturn = ThenArg<RunServerlessPromiseReturn>;
 
 const serverlessPackage = process.env.SERVERLESS_TEST_PACKAGE ?? "osls";
-const serverlessDir = path.dirname(require.resolve(`${serverlessPackage}/package.json`));
+const serverlessDir = path.resolve(__dirname, `../../node_modules/${serverlessPackage}`);
+
+// Jest 27 runs tests in a VM context that does not expose all Node 20 globals.
+// Latest OSLS dependencies expect these web platform APIs to be available.
+[
+    "structuredClone",
+    "ReadableStream",
+    "Blob",
+    "File",
+    "URLSearchParams",
+    "URL",
+    "AbortSignal",
+    "MessagePort",
+    "DOMException",
+].forEach((globalName) => {
+    if (!(globalName in globalThis)) {
+        Object.assign(globalThis, {
+            [globalName]: runInThisContext(globalName) as unknown,
+        });
+    }
+});
 
 const computeLogicalId = (serverless: Serverless, ...address: string[]): string => {
     const initialNode = serverless.stack.node;

--- a/test/utils/runServerless.ts
+++ b/test/utils/runServerless.ts
@@ -11,6 +11,9 @@ type RunServerlessPromiseReturn = ReturnType<typeof originalRunServerless>;
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 type RunServerlessReturn = ThenArg<RunServerlessPromiseReturn>;
 
+const serverlessPackage = process.env.SERVERLESS_TEST_PACKAGE ?? "osls";
+const serverlessDir = path.dirname(require.resolve(`${serverlessPackage}/package.json`));
+
 const computeLogicalId = (serverless: Serverless, ...address: string[]): string => {
     const initialNode = serverless.stack.node;
     const foundNode = [...address].reduce((currentNode, nextNodeId) => {
@@ -39,7 +42,7 @@ export const runServerless = async (
 ): Promise<RunServerlessReturn & { computeLogicalId: ComputeLogicalId }> => {
     const runServerlessReturnValues = await setupRunServerlessFixturesEngine({
         fixturesDir: path.resolve(__dirname, "../fixtures"),
-        serverlessDir: path.resolve(__dirname, "../../node_modules/serverless"),
+        serverlessDir,
     })(options);
 
     return {


### PR DESCRIPTION
## Summary
- Reapplies the dependency update from #425 on top of current master.
- Uses OSLS for local development/builds while keeping both OSLS and Serverless Framework as optional peers.
- Updates the unit-test harness and CI matrix to exercise both `osls` and `serverless@3`.

## Test plan
- `npm run check-format`
- `npm run lint`
- `npm run type`
- `npm test -- --runInBand`
- `SERVERLESS_TEST_PACKAGE=serverless npm test -- --runInBand` after temporarily installing `serverless@3.40.0`

Replaces #425.