### PR TITLE
Storage: allow exposing paths publicly

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -40,6 +40,10 @@ All storage constructs expose the following variables:
 - `bucketName`: the name of the deployed S3 bucket
 - `bucketArn`: the ARN of the deployed S3 bucket
 
+When [`publicPath`](#public-files) is set, an additional variable is exposed:
+
+- `publicUrl`: the base URL of the bucket (e.g. `https://<bucket>.s3.<region>.amazonaws.com`), used to build URLs to public files
+
 This can be used to reference the bucket from Lambda functions, for example:
 
 ```yaml
@@ -159,6 +163,23 @@ constructs:
 ```
 
 The full form maps directly to [CloudFormation CorsRules](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-corsconfiguration-corsrule.html).
+
+### Public files
+
+By default, the bucket is completely private. To expose **a subset** of the bucket publicly (for example user-uploaded avatars served on a website), use `publicPath`:
+
+```yaml
+constructs:
+    avatars:
+        type: storage
+        publicPath: public
+```
+
+Every object stored under the `public/` prefix immediately becomes **publicly readable** over HTTPS (via a bucket policy), while the rest of the bucket stays private. Files are served directly from S3 at `https://<bucket>.s3.<region>.amazonaws.com/public/...`.
+
+Unlike the `assets` of the [`server-side-website`](server-side-website.md) construct, a `storage` bucket is **never emptied or cleared on deploy**, which makes `publicPath` the right place for files generated or uploaded by the application at runtime.
+
+`publicPath` must be a sub-path (e.g. `public`) — `/` or `*` are rejected, as they would expose the whole bucket.
 
 ## Extensions
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -179,7 +179,16 @@ Every object stored under the `public/` prefix immediately becomes **publicly re
 
 Unlike the `assets` of the [`server-side-website`](server-side-website.md) construct, a `storage` bucket is **never emptied or cleared on deploy**, which makes `publicPath` the right place for files generated or uploaded by the application at runtime.
 
-`publicPath` must be a sub-path (e.g. `public`) — `/` or `*` are rejected, as they would expose the whole bucket.
+To make the **entire bucket** public instead of a single prefix, set `publicPath` to `/` or `*`:
+
+```yaml
+constructs:
+    avatars:
+        type: storage
+        publicPath: "*" # every object in the bucket is publicly readable
+```
+
+⚠️ With `/` or `*`, _all_ files in the bucket are publicly readable — only do this for buckets that store exclusively public files. Prefer a sub-path (e.g. `public`) when the bucket also holds private files.
 
 ## Extensions
 

--- a/src/constructs/aws/Storage.ts
+++ b/src/constructs/aws/Storage.ts
@@ -8,7 +8,6 @@ import type { FromSchema } from "json-schema-to-ts";
 import type { AwsProvider } from "@lift/providers";
 import { AwsConstruct } from "@lift/constructs/abstracts";
 import { PolicyStatement } from "../../CloudFormation";
-import ServerlessError from "../../utils/error";
 
 const STORAGE_DEFINITION = {
     type: "object",
@@ -60,23 +59,24 @@ function capitalizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
 }
 
 /**
- * Validate and normalize the `publicPath` option into a bare key prefix (no leading/trailing slash).
+ * Normalize the `publicPath` option into the S3 object key pattern that is made public (i.e. the
+ * part appended after the bucket ARN in the public-read bucket policy).
  * Returns undefined when `publicPath` is not set.
+ *
+ * - `public`            -> `public/*` (only that prefix is public)
+ * - `/`, `*` or empty   -> `*`        (the whole bucket is public)
  */
-function normalizePublicPath(id: string, publicPath: string | undefined): string | undefined {
+function normalizePublicPath(publicPath: string | undefined): string | undefined {
     if (publicPath === undefined) {
         return undefined;
     }
 
     const prefix = publicPath.replace(/^\/+/, "").replace(/\/+$/, "");
     if (prefix === "" || prefix === "*") {
-        throw new ServerlessError(
-            `Invalid configuration in 'constructs.${id}.publicPath': it must be a sub-path (e.g. 'public') so that only that prefix is made public. '${publicPath}' would expose the whole bucket.`,
-            "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
-        );
+        return "*";
     }
 
-    return prefix;
+    return `${prefix}/*`;
 }
 
 type Configuration = FromSchema<typeof STORAGE_DEFINITION>;
@@ -87,7 +87,7 @@ export class Storage extends AwsConstruct {
 
     private readonly bucket: Bucket;
     private readonly allowAcl: boolean;
-    private readonly publicPrefix: string | undefined;
+    private readonly publicObjects: string | undefined;
     // a remplacer par StorageExtensionsKeys
     private readonly bucketNameOutput: CfnOutput;
 
@@ -96,7 +96,7 @@ export class Storage extends AwsConstruct {
 
         const resolvedConfiguration = Object.assign({}, STORAGE_DEFAULTS, configuration);
         this.allowAcl = resolvedConfiguration.allowAcl === true;
-        this.publicPrefix = normalizePublicPath(id, resolvedConfiguration.publicPath);
+        this.publicObjects = normalizePublicPath(resolvedConfiguration.publicPath);
 
         const encryptionOptions = {
             s3: BucketEncryption.S3_MANAGED,
@@ -110,7 +110,7 @@ export class Storage extends AwsConstruct {
             // *policy* levers (so the public-read bucket policy below can take effect) — ACLs stay
             // the legacy path. See the public access matrix in the docs.
             blockPublicAccess:
-                this.publicPrefix === undefined
+                this.publicObjects === undefined
                     ? BlockPublicAccess.BLOCK_ALL
                     : new BlockPublicAccess({
                           // With `allowAcl`, accept public-ACL writes (e.g. Laravel's `storePublicly()`)
@@ -124,16 +124,16 @@ export class Storage extends AwsConstruct {
             enforceSSL: true,
         });
 
-        if (this.publicPrefix !== undefined) {
-            // Grant anonymous read to objects under the public prefix only — everything else stays
-            // private. `GetObject` only (no `ListBucket`), so the prefix cannot be listed.
-            // This statement is appended to the same bucket policy as the `enforceSSL` deny statement.
+        if (this.publicObjects !== undefined) {
+            // Grant anonymous read to the public objects (a single prefix, or the whole bucket when
+            // `publicPath` is `/` or `*`). `GetObject` only (no `ListBucket`), so objects cannot be
+            // listed. Appended to the same bucket policy as the `enforceSSL` deny statement.
             this.bucket.addToResourcePolicy(
                 new IamPolicyStatement({
                     effect: Effect.ALLOW,
                     principals: [new AnyPrincipal()],
                     actions: ["s3:GetObject"],
-                    resources: [`${this.bucket.bucketArn}/${this.publicPrefix}/*`],
+                    resources: [`${this.bucket.bucketArn}/${this.publicObjects}`],
                 })
             );
         }
@@ -205,7 +205,7 @@ export class Storage extends AwsConstruct {
             bucketName: this.bucket.bucketName,
         };
 
-        if (this.publicPrefix !== undefined) {
+        if (this.publicObjects !== undefined) {
             // Base URL of the bucket (no key), e.g. https://<bucket>.s3.<region>.amazonaws.com
             variables.publicUrl = this.bucket.virtualHostedUrlForObject();
         }

--- a/src/constructs/aws/Storage.ts
+++ b/src/constructs/aws/Storage.ts
@@ -3,10 +3,12 @@ import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3"
 import type { Construct as CdkConstruct } from "constructs";
 import { CfnOutput, Fn, Stack } from "aws-cdk-lib";
 import type { CfnResource } from "aws-cdk-lib";
+import { AnyPrincipal, Effect, PolicyStatement as IamPolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { FromSchema } from "json-schema-to-ts";
 import type { AwsProvider } from "@lift/providers";
 import { AwsConstruct } from "@lift/constructs/abstracts";
 import { PolicyStatement } from "../../CloudFormation";
+import ServerlessError from "../../utils/error";
 
 const STORAGE_DEFINITION = {
     type: "object",
@@ -17,6 +19,7 @@ const STORAGE_DEFINITION = {
             anyOf: [{ const: "s3" }, { const: "kms" }],
         },
         allowAcl: { type: "boolean" },
+        publicPath: { type: "string" },
         cors: {
             anyOf: [{ type: "array", items: { type: "object" } }, { type: "string" }],
         },
@@ -27,7 +30,7 @@ const STORAGE_DEFINITION = {
     },
     additionalProperties: false,
 } as const;
-const STORAGE_DEFAULTS: Omit<Required<FromSchema<typeof STORAGE_DEFINITION>>, "allowAcl" | "cors"> = {
+const STORAGE_DEFAULTS: Omit<Required<FromSchema<typeof STORAGE_DEFINITION>>, "allowAcl" | "cors" | "publicPath"> = {
     type: "storage",
     archive: 45,
     encryption: "s3",
@@ -56,6 +59,26 @@ function capitalizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
     return result;
 }
 
+/**
+ * Validate and normalize the `publicPath` option into a bare key prefix (no leading/trailing slash).
+ * Returns undefined when `publicPath` is not set.
+ */
+function normalizePublicPath(id: string, publicPath: string | undefined): string | undefined {
+    if (publicPath === undefined) {
+        return undefined;
+    }
+
+    const prefix = publicPath.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (prefix === "" || prefix === "*") {
+        throw new ServerlessError(
+            `Invalid configuration in 'constructs.${id}.publicPath': it must be a sub-path (e.g. 'public') so that only that prefix is made public. '${publicPath}' would expose the whole bucket.`,
+            "LIFT_INVALID_CONSTRUCT_CONFIGURATION"
+        );
+    }
+
+    return prefix;
+}
+
 type Configuration = FromSchema<typeof STORAGE_DEFINITION>;
 
 export class Storage extends AwsConstruct {
@@ -64,6 +87,7 @@ export class Storage extends AwsConstruct {
 
     private readonly bucket: Bucket;
     private readonly allowAcl: boolean;
+    private readonly publicPrefix: string | undefined;
     // a remplacer par StorageExtensionsKeys
     private readonly bucketNameOutput: CfnOutput;
 
@@ -72,6 +96,7 @@ export class Storage extends AwsConstruct {
 
         const resolvedConfiguration = Object.assign({}, STORAGE_DEFAULTS, configuration);
         this.allowAcl = resolvedConfiguration.allowAcl === true;
+        this.publicPrefix = normalizePublicPath(id, resolvedConfiguration.publicPath);
 
         const encryptionOptions = {
             s3: BucketEncryption.S3_MANAGED,
@@ -81,9 +106,37 @@ export class Storage extends AwsConstruct {
         this.bucket = new Bucket(this, "Bucket", {
             encryption: encryptionOptions[resolvedConfiguration.encryption],
             versioned: true,
-            blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            // By default the bucket is fully private. When `publicPath` is set, we only open the
+            // *policy* levers (so the public-read bucket policy below can take effect) — ACLs stay
+            // the legacy path. See the public access matrix in the docs.
+            blockPublicAccess:
+                this.publicPrefix === undefined
+                    ? BlockPublicAccess.BLOCK_ALL
+                    : new BlockPublicAccess({
+                          // With `allowAcl`, accept public-ACL writes (e.g. Laravel's `storePublicly()`)
+                          // but keep them inert via `ignorePublicAcls`; the bucket policy is the only
+                          // thing that ever grants public access.
+                          blockPublicAcls: !this.allowAcl,
+                          ignorePublicAcls: true,
+                          blockPublicPolicy: false,
+                          restrictPublicBuckets: false,
+                      }),
             enforceSSL: true,
         });
+
+        if (this.publicPrefix !== undefined) {
+            // Grant anonymous read to objects under the public prefix only — everything else stays
+            // private. `GetObject` only (no `ListBucket`), so the prefix cannot be listed.
+            // This statement is appended to the same bucket policy as the `enforceSSL` deny statement.
+            this.bucket.addToResourcePolicy(
+                new IamPolicyStatement({
+                    effect: Effect.ALLOW,
+                    principals: [new AnyPrincipal()],
+                    actions: ["s3:GetObject"],
+                    resources: [`${this.bucket.bucketArn}/${this.publicPrefix}/*`],
+                })
+            );
+        }
 
         // Default lifecycle rules (always applied)
         const defaultRules = [
@@ -147,10 +200,17 @@ export class Storage extends AwsConstruct {
     }
 
     variables(): Record<string, unknown> {
-        return {
+        const variables: Record<string, unknown> = {
             bucketArn: this.bucket.bucketArn,
             bucketName: this.bucket.bucketName,
         };
+
+        if (this.publicPrefix !== undefined) {
+            // Base URL of the bucket (no key), e.g. https://<bucket>.s3.<region>.amazonaws.com
+            variables.publicUrl = this.bucket.virtualHostedUrlForObject();
+        }
+
+        return variables;
     }
 
     permissions(): PolicyStatement[] {

--- a/test/fixtures/storage/serverless.yml
+++ b/test/fixtures/storage/serverless.yml
@@ -42,6 +42,12 @@ constructs:
         type: storage
         publicPath: /public/
         allowAcl: true
+    withPublicPathSlash:
+        type: storage
+        publicPath: /
+    withPublicPathStar:
+        type: storage
+        publicPath: "*"
     withCorsString:
         type: storage
         cors: "*"

--- a/test/fixtures/storage/serverless.yml
+++ b/test/fixtures/storage/serverless.yml
@@ -35,6 +35,13 @@ constructs:
     withAcl:
         type: storage
         allowAcl: true
+    withPublicPath:
+        type: storage
+        publicPath: public
+    withPublicPathAndAcl:
+        type: storage
+        publicPath: /public/
+        allowAcl: true
     withCorsString:
         type: storage
         cors: "*"

--- a/test/unit/storage.test.ts
+++ b/test/unit/storage.test.ts
@@ -1,4 +1,4 @@
-import { baseConfig, pluginConfigExt, runServerless } from "../utils/runServerless";
+import { pluginConfigExt, runServerless } from "../utils/runServerless";
 
 describe("storage", () => {
     let cfTemplate: { Resources: Record<string, { Properties: Record<string, unknown> }> };
@@ -190,23 +190,21 @@ describe("storage", () => {
         });
     });
 
-    it("rejects a publicPath that would expose the whole bucket", async () => {
-        await expect(() => {
-            return runServerless({
-                command: "package",
-                config: Object.assign({}, baseConfig, {
-                    constructs: {
-                        avatars: {
-                            type: "storage",
-                            publicPath: "/",
-                        },
-                    },
-                }),
+    it.each([["withPublicPathSlash"], ["withPublicPathStar"]])(
+        "makes the whole bucket public when publicPath is '/' or '*' (%p)",
+        (useCase) => {
+            const bucketLogicalId = computeLogicalId(useCase, "Bucket");
+            const policy = cfTemplate.Resources[computeLogicalId(useCase, "Bucket", "Policy")].Properties
+                .PolicyDocument as { Statement: unknown[] };
+            expect(policy.Statement).toContainEqual({
+                Action: "s3:GetObject",
+                Effect: "Allow",
+                Principal: { AWS: "*" },
+                // The whole bucket (every object) is public, not just a prefix
+                Resource: { "Fn::Join": ["", [{ "Fn::GetAtt": [bucketLogicalId, "Arn"] }, "/*"]] },
             });
-        }).rejects.toThrowError(
-            "Invalid configuration in 'constructs.avatars.publicPath': it must be a sub-path (e.g. 'public') so that only that prefix is made public. '/' would expose the whole bucket."
-        );
-    });
+        }
+    );
 
     it("supports custom lifecycleRules with auto-capitalization and default Status", () => {
         const lifecycleConfig = cfTemplate.Resources[computeLogicalId("withLifecycleRules", "Bucket")].Properties

--- a/test/unit/storage.test.ts
+++ b/test/unit/storage.test.ts
@@ -1,4 +1,4 @@
-import { pluginConfigExt, runServerless } from "../utils/runServerless";
+import { baseConfig, pluginConfigExt, runServerless } from "../utils/runServerless";
 
 describe("storage", () => {
     let cfTemplate: { Resources: Record<string, { Properties: Record<string, unknown> }> };
@@ -123,6 +123,89 @@ describe("storage", () => {
                 ],
             },
         });
+    });
+
+    it("should block all public access by default", () => {
+        expect(cfTemplate.Resources[computeLogicalId("default", "Bucket")].Properties).toMatchObject({
+            PublicAccessBlockConfiguration: {
+                BlockPublicAcls: true,
+                BlockPublicPolicy: true,
+                IgnorePublicAcls: true,
+                RestrictPublicBuckets: true,
+            },
+        });
+    });
+
+    it("should open only the policy levers when publicPath is set", () => {
+        expect(cfTemplate.Resources[computeLogicalId("withPublicPath", "Bucket")].Properties).toMatchObject({
+            PublicAccessBlockConfiguration: {
+                // ACL writes still rejected (strict, no allowAcl)
+                BlockPublicAcls: true,
+                IgnorePublicAcls: true,
+                // Policy levers opened so the public-read bucket policy can take effect
+                BlockPublicPolicy: false,
+                RestrictPublicBuckets: false,
+            },
+        });
+    });
+
+    it("should grant anonymous read scoped to the public prefix only", () => {
+        const bucketLogicalId = computeLogicalId("withPublicPath", "Bucket");
+        const policy = cfTemplate.Resources[computeLogicalId("withPublicPath", "Bucket", "Policy")].Properties
+            .PolicyDocument as { Statement: unknown[] };
+        expect(policy.Statement).toContainEqual({
+            Action: "s3:GetObject",
+            Effect: "Allow",
+            Principal: { AWS: "*" },
+            Resource: { "Fn::Join": ["", [{ "Fn::GetAtt": [bucketLogicalId, "Arn"] }, "/public/*"]] },
+        });
+    });
+
+    it("should accept-but-ignore public ACLs when publicPath is combined with allowAcl", () => {
+        expect(cfTemplate.Resources[computeLogicalId("withPublicPathAndAcl", "Bucket")].Properties).toMatchObject({
+            // storePublicly()/visibility:public writes are accepted...
+            PublicAccessBlockConfiguration: {
+                BlockPublicAcls: false,
+                // ...but the public ACL is inert; the bucket policy is the only public-access mechanism
+                IgnorePublicAcls: true,
+                BlockPublicPolicy: false,
+                RestrictPublicBuckets: false,
+            },
+            OwnershipControls: {
+                Rules: [{ ObjectOwnership: "BucketOwnerPreferred" }],
+            },
+        });
+    });
+
+    it("normalizes the publicPath prefix (strips leading/trailing slashes)", () => {
+        // 'withPublicPathAndAcl' is configured with `publicPath: /public/`
+        const bucketLogicalId = computeLogicalId("withPublicPathAndAcl", "Bucket");
+        const policy = cfTemplate.Resources[computeLogicalId("withPublicPathAndAcl", "Bucket", "Policy")].Properties
+            .PolicyDocument as { Statement: unknown[] };
+        expect(policy.Statement).toContainEqual({
+            Action: "s3:GetObject",
+            Effect: "Allow",
+            Principal: { AWS: "*" },
+            Resource: { "Fn::Join": ["", [{ "Fn::GetAtt": [bucketLogicalId, "Arn"] }, "/public/*"]] },
+        });
+    });
+
+    it("rejects a publicPath that would expose the whole bucket", async () => {
+        await expect(() => {
+            return runServerless({
+                command: "package",
+                config: Object.assign({}, baseConfig, {
+                    constructs: {
+                        avatars: {
+                            type: "storage",
+                            publicPath: "/",
+                        },
+                    },
+                }),
+            });
+        }).rejects.toThrowError(
+            "Invalid configuration in 'constructs.avatars.publicPath': it must be a sub-path (e.g. 'public') so that only that prefix is made public. '/' would expose the whole bucket."
+        );
     });
 
     it("supports custom lifecycleRules with auto-capitalization and default Status", () => {


### PR DESCRIPTION
This adds a new `publicPath` option to the storage construct to expose some paths publicly:

```yaml
constructs:
    avatars:
        type: storage
        publicPath: public
```

> By default, the bucket is completely private. To expose **a subset** of the bucket publicly (for example user-uploaded avatars served on a website), use `publicPath`.
>
> Every object stored under the `public/` prefix immediately becomes **publicly readable** over HTTPS (via a bucket policy), while the rest of the bucket stays private. Files are served directly from S3 at `https://<bucket>.s3.<region>.amazonaws.com/public/...`.
>
> Unlike the `assets` of the [`server-side-website`](server-side-website.md) construct, a `storage` bucket is **never emptied or cleared on deploy**, which makes `publicPath` the right place for files generated or uploaded by the application at runtime.