### PR TITLE
Fix versioned asset predeploy sync

### DIFF
--- a/docs/server-side-website.md
+++ b/docs/server-side-website.md
@@ -239,11 +239,11 @@ constructs:
 
 This is useful for frameworks such as Laravel with Vite, where the deployed PHP code references asset paths from a manifest file.
 
-When `versionedAssets` is enabled, Lift uploads assets **before** the CloudFormation deployment starts, so the new hashed files are already available by the time the new Lambda code is deployed.
+When `versionedAssets` is enabled, Lift uploads new assets **before** the CloudFormation deployment starts, so new hashed files are already available by the time the new Lambda code is deployed. Assets that already exist in S3 are updated after CloudFormation has successfully deployed, like with the default deployment behavior.
 
 Lift also keeps obsolete files in S3 temporarily instead of deleting them immediately (they are marked for deletion and cleaned up by S3 after 1 day).
 
-If your asset URLs do not contain a version/hash/fingerprint, do not enable this: assets would be updated before the new code is deployed, so users would receive the new asset versions while still running the old code.
+If your asset URLs do not contain a version/hash/fingerprint, this option is not useful: assets are still updated after the new code is deployed.
 
 ### API Gateway
 

--- a/src/constructs/aws/ServerSideWebsite.ts
+++ b/src/constructs/aws/ServerSideWebsite.ts
@@ -27,7 +27,7 @@ import { AwsConstruct } from "@lift/constructs/abstracts";
 import type { ConstructCommands } from "@lift/constructs";
 import type { AwsProvider } from "@lift/providers";
 import { ensureNameMaxLength } from "../../utils/naming";
-import { s3PutIfChanged, s3Sync } from "../../utils/s3-sync";
+import { s3PutIfChanged, s3PutIfMissing, s3Sync } from "../../utils/s3-sync";
 import type { S3SyncDeleteMode, S3SyncUploadMode } from "../../utils/s3-sync";
 import { emptyBucket, invalidateCloudFrontCache } from "../../classes/aws";
 import ServerlessError from "../../utils/error";
@@ -75,10 +75,6 @@ type UploadAssetsOptions = {
     clearCache: boolean;
     forceCacheClear?: boolean;
 };
-type UploadAssetsResult = {
-    bucketFound: boolean;
-    hasChanges: boolean;
-};
 
 export class ServerSideWebsite extends AwsConstruct {
     public static type = "server-side-website";
@@ -97,7 +93,6 @@ export class ServerSideWebsite extends AwsConstruct {
     private readonly domainOutput: CfnOutput;
     private readonly cnameOutput: CfnOutput;
     private readonly distributionIdOutput: CfnOutput;
-    private preDeployAssetsSynced = false;
     private preDeployCacheInvalidationNeeded = false;
 
     constructor(
@@ -245,31 +240,28 @@ export class ServerSideWebsite extends AwsConstruct {
         }
 
         const result = await this.uploadAssets({
-            uploadMode: "sync",
+            uploadMode: "missing",
             deleteMode: "none",
-            restoreObsoleteTags: true,
+            restoreObsoleteTags: false,
             failOnMissingBucket: false,
             clearCache: false,
         });
-        this.preDeployAssetsSynced = result.bucketFound;
         // The cache clearing is deferred to postDeploy (preDeploy runs before the new code is live).
         this.preDeployCacheInvalidationNeeded = result.hasChanges;
     }
 
     async postDeploy(): Promise<void> {
         const versionedAssets = this.configuration.versionedAssets === true;
-        const assetsAlreadySynced = versionedAssets && this.preDeployAssetsSynced;
 
         await this.uploadAssets({
-            uploadMode: assetsAlreadySynced ? "none" : "sync",
+            uploadMode: "sync",
             deleteMode: versionedAssets ? "tag" : "delete",
-            restoreObsoleteTags: versionedAssets && !assetsAlreadySynced,
+            restoreObsoleteTags: versionedAssets,
             failOnMissingBucket: true,
             clearCache: true,
             forceCacheClear: this.preDeployCacheInvalidationNeeded,
         });
 
-        this.preDeployAssetsSynced = false;
         this.preDeployCacheInvalidationNeeded = false;
     }
 
@@ -291,11 +283,11 @@ export class ServerSideWebsite extends AwsConstruct {
         }
     }
 
-    async uploadAssets(options: UploadAssetsOptions): Promise<UploadAssetsResult> {
+    async uploadAssets(options: UploadAssetsOptions): Promise<{ hasChanges: boolean }> {
         const bucketName = await this.getBucketName();
         if (bucketName === undefined) {
             if (!options.failOnMissingBucket) {
-                return { bucketFound: false, hasChanges: false };
+                return { hasChanges: false };
             }
 
             throw new ServerlessError(
@@ -308,7 +300,7 @@ export class ServerSideWebsite extends AwsConstruct {
         let uploadProgress: Progress | undefined;
         if (progress) {
             uploadProgress = progress.create({
-                message: options.uploadMode === "sync" ? "Uploading assets" : "Cleaning up obsolete assets",
+                message: options.uploadMode !== "none" ? "Uploading assets" : "Cleaning up obsolete assets",
             });
         }
 
@@ -328,7 +320,7 @@ export class ServerSideWebsite extends AwsConstruct {
             if (fs.lstatSync(filePath).isDirectory()) {
                 // Directory
                 const uploadMessage =
-                    options.uploadMode === "sync"
+                    options.uploadMode !== "none"
                         ? `Uploading '${filePath}' to 's3://${bucketName}/${s3PathPrefix}'`
                         : `Cleaning up obsolete assets in 's3://${bucketName}/${s3PathPrefix}'`;
                 if (uploadProgress) {
@@ -358,15 +350,13 @@ export class ServerSideWebsite extends AwsConstruct {
                 } else {
                     getUtils().log(`Uploading '${filePath}' to 's3://${bucketName}/${targetKey}'`);
                 }
-                const fileHasChanges = await s3PutIfChanged(
-                    this.provider,
-                    bucketName,
-                    targetKey,
-                    fs.readFileSync(filePath),
-                    {
-                        removeObsoleteTag: options.restoreObsoleteTags,
-                    }
-                );
+                const fileContent = fs.readFileSync(filePath);
+                const fileHasChanges =
+                    options.uploadMode === "missing"
+                        ? await s3PutIfMissing(this.provider, bucketName, targetKey, fileContent)
+                        : await s3PutIfChanged(this.provider, bucketName, targetKey, fileContent, {
+                              removeObsoleteTag: options.restoreObsoleteTags,
+                          });
                 hasChanges = hasChanges || fileHasChanges;
             }
         }
@@ -386,7 +376,7 @@ export class ServerSideWebsite extends AwsConstruct {
             uploadProgress.remove();
         }
 
-        return { bucketFound: true, hasChanges };
+        return { hasChanges };
     }
 
     private async clearCDNCache(): Promise<void> {

--- a/src/utils/s3-sync.ts
+++ b/src/utils/s3-sync.ts
@@ -8,6 +8,7 @@ import {
     PutObjectTaggingCommand,
 } from "@aws-sdk/client-s3";
 import type {
+    CopyObjectCommandInput,
     HeadObjectCommandOutput,
     ListObjectsV2CommandOutput,
     PutObjectCommandInput,
@@ -33,7 +34,7 @@ const TAGGING_BATCH_SIZE = 10;
 
 type S3Objects = Record<string, S3Object>;
 export type S3SyncDeleteMode = "delete" | "tag" | "none";
-export type S3SyncUploadMode = "sync" | "none";
+export type S3SyncUploadMode = "sync" | "missing" | "none";
 
 /**
  * Synchronize a local folder to a S3 bucket.
@@ -63,16 +64,21 @@ export async function s3Sync({
     const existingS3Objects = await s3ListAll(aws, bucketName, targetPathPrefix);
 
     let skippedFiles = 0;
-    if (uploadMode === "sync") {
+    if (uploadMode !== "none") {
         // Upload files by chunks
         for (const batch of chunk(filesToUpload, S3_UPLOAD_CONCURRENCY)) {
             await Promise.all(
                 batch.map(async (file) => {
                     const targetKey = targetPathPrefix !== undefined ? path.posix.join(targetPathPrefix, file) : file;
-                    const fileContent = await readFile(path.posix.join(localPath, file));
 
-                    // Check that the file isn't already uploaded
                     if (targetKey in existingS3Objects) {
+                        if (uploadMode === "missing") {
+                            skippedFiles++;
+
+                            return;
+                        }
+
+                        const fileContent = await readFile(path.posix.join(localPath, file));
                         const existingObject = existingS3Objects[targetKey];
                         const etag = computeS3ETag(fileContent);
                         if (etag === existingObject.ETag) {
@@ -88,8 +94,16 @@ export async function s3Sync({
 
                             return;
                         }
+
+                        getUtils().log.verbose(`Uploading ${file}`);
+                        await s3Put(aws, bucketName, targetKey, fileContent);
+                        hasChanges = true;
+                        fileChangeCount++;
+
+                        return;
                     }
 
+                    const fileContent = await readFile(path.posix.join(localPath, file));
                     getUtils().log.verbose(`Uploading ${file}`);
                     await s3Put(aws, bucketName, targetKey, fileContent);
                     hasChanges = true;
@@ -98,7 +112,7 @@ export async function s3Sync({
             );
         }
         if (skippedFiles > 0) {
-            getUtils().log.verbose(`Skipped uploading ${skippedFiles} unchanged files`);
+            getUtils().log.verbose(`Skipped uploading ${skippedFiles} existing or unchanged files`);
         }
     }
 
@@ -220,8 +234,7 @@ export async function s3PutIfChanged(
             return false;
         }
     } catch (error) {
-        const code = (error as { code?: string; name?: string }).code ?? (error as { name?: string }).name;
-        if (code !== "NotFound" && code !== "NoSuchKey") {
+        if (!isMissingObjectError(error)) {
             throw error;
         }
     }
@@ -229,6 +242,40 @@ export async function s3PutIfChanged(
     await s3Put(aws, bucket, key, fileContent);
 
     return true;
+}
+
+export async function s3PutIfMissing(
+    aws: AwsProvider,
+    bucket: string,
+    key: string,
+    fileContent: Buffer
+): Promise<boolean> {
+    try {
+        await (
+            await aws.getS3Client()
+        ).send(
+            new HeadObjectCommand({
+                Bucket: bucket,
+                Key: key,
+            })
+        );
+
+        return false;
+    } catch (error) {
+        if (!isMissingObjectError(error)) {
+            throw error;
+        }
+    }
+
+    await s3Put(aws, bucket, key, fileContent);
+
+    return true;
+}
+
+function isMissingObjectError(error: unknown): boolean {
+    const code = (error as { code?: string; name?: string }).code ?? (error as { name?: string }).name;
+
+    return code === "NotFound" || code === "NoSuchKey";
 }
 
 async function s3Delete(aws: AwsProvider, bucket: string, keys: string[]): Promise<string[]> {
@@ -316,11 +363,16 @@ async function s3TagAsObsolete(aws: AwsProvider, bucket: string, keys: string[])
                         return false;
                     }
 
+                    const existingObject = await s3Client.send(
+                        new HeadObjectCommand({
+                            Bucket: bucket,
+                            Key: key,
+                        })
+                    );
                     // Copy the object onto itself to refresh LastModified (so the lifecycle expiry
-                    // counts from now) and set the Obsolete tag in the same call. Setting the tag
-                    // here (rather than via a separate PutObjectTagging) avoids a window where the
-                    // copy could read a not-yet-propagated tag and produce an untagged object that
-                    // never expires. The full tag set is provided so existing tags are preserved.
+                    // counts from now) and set the Obsolete tag in the same call. S3 rejects
+                    // self-copies that only change tags, so we preserve the existing metadata and add
+                    // a Lift-owned marker to make this a valid metadata update.
                     const tagging = [
                         ...currentTagSet.filter((tag) => tag.Key !== "Obsolete"),
                         { Key: "Obsolete", Value: "true" },
@@ -329,14 +381,7 @@ async function s3TagAsObsolete(aws: AwsProvider, bucket: string, keys: string[])
                         .join("&");
                     const encodedKey = encodeURIComponent(key).replace(/%2F/g, "/");
                     await s3Client.send(
-                        new CopyObjectCommand({
-                            Bucket: bucket,
-                            Key: key,
-                            CopySource: `${bucket}/${encodedKey}`,
-                            MetadataDirective: "COPY",
-                            TaggingDirective: "REPLACE",
-                            Tagging: tagging,
-                        })
+                        new CopyObjectCommand(copyObjectParams(bucket, key, encodedKey, tagging, existingObject))
                     );
 
                     return true;
@@ -358,6 +403,34 @@ async function s3TagAsObsolete(aws: AwsProvider, bucket: string, keys: string[])
             "LIFT_S3_TAG_OBJECTS_FAILURE"
         );
     }
+}
+
+function copyObjectParams(
+    bucket: string,
+    key: string,
+    encodedKey: string,
+    tagging: string,
+    existingObject: HeadObjectCommandOutput
+): CopyObjectCommandInput {
+    return {
+        Bucket: bucket,
+        Key: key,
+        CopySource: `${bucket}/${encodedKey}`,
+        MetadataDirective: "REPLACE",
+        Metadata: {
+            ...existingObject.Metadata,
+            "lift-obsolete-at": new Date().toISOString(),
+        },
+        TaggingDirective: "REPLACE",
+        Tagging: tagging,
+        CacheControl: existingObject.CacheControl,
+        ContentDisposition: existingObject.ContentDisposition,
+        ContentEncoding: existingObject.ContentEncoding,
+        ContentLanguage: existingObject.ContentLanguage,
+        ContentType: existingObject.ContentType,
+        Expires: existingObject.Expires,
+        WebsiteRedirectLocation: existingObject.WebsiteRedirectLocation,
+    };
 }
 
 export function computeS3ETag(fileContent: Buffer): string {

--- a/test/unit/s3Sync.test.ts
+++ b/test/unit/s3Sync.test.ts
@@ -10,6 +10,37 @@ describe("s3 sync", () => {
         sinon.restore();
     });
 
+    it("can upload only files that are missing from S3", async () => {
+        const awsMock = mockAws();
+        const awsProvider = {
+            getS3Client: () => Promise.resolve(new S3Client({ region: "us-east-1" })),
+        } as AwsProvider;
+
+        awsMock.mockService("S3", "listObjectsV2").resolves({
+            IsTruncated: false,
+            Contents: [{ Key: "assets/logo.png" }, { Key: "assets/styles.css" }],
+        });
+        const putObjectSpy = awsMock.mockService("S3", "putObject");
+        const deleteObjectsSpy = awsMock.mockService("S3", "deleteObjects");
+
+        const result = await s3Sync({
+            aws: awsProvider,
+            localPath: path.join(__dirname, "../fixtures/serverSideWebsite/public"),
+            targetPathPrefix: "assets",
+            bucketName: "bucket-name",
+            uploadMode: "missing",
+            deleteMode: "none",
+        });
+
+        expect(result).toEqual({ hasChanges: true, fileChangeCount: 1 });
+        sinon.assert.calledOnce(putObjectSpy);
+        expect(putObjectSpy.firstCall.firstArg).toMatchObject({
+            Bucket: "bucket-name",
+            Key: "assets/scripts.js",
+        });
+        sinon.assert.notCalled(deleteObjectsSpy);
+    });
+
     it("can tag obsolete files without reading tags from current files", async () => {
         const awsMock = mockAws();
         const awsProvider = {
@@ -22,6 +53,10 @@ describe("s3 sync", () => {
         });
         const putObjectSpy = awsMock.mockService("S3", "putObject");
         const getObjectTaggingSpy = awsMock.mockService("S3", "getObjectTagging").resolves({ TagSet: [] });
+        awsMock.mockService("S3", "headObject").resolves({
+            ContentType: "image/png",
+            Metadata: { cache: "forever" },
+        });
         const putObjectTaggingSpy = awsMock.mockService("S3", "putObjectTagging").resolves({});
         const copyObjectSpy = awsMock.mockService("S3", "copyObject").resolves({});
 
@@ -48,9 +83,16 @@ describe("s3 sync", () => {
         expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
             Bucket: "bucket-name",
             Key: "assets/old.png",
+            MetadataDirective: "REPLACE",
+            Metadata: {
+                cache: "forever",
+            },
+            ContentType: "image/png",
             TaggingDirective: "REPLACE",
             Tagging: "Obsolete=true",
         });
+        const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+        expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
     });
 
     it("preserves existing tags (and URL-encodes them) when tagging an obsolete file", async () => {
@@ -64,6 +106,10 @@ describe("s3 sync", () => {
             Contents: [{ Key: "assets/logo.png" }, { Key: "assets/old.png" }],
         });
         const copyObjectSpy = awsMock.mockService("S3", "copyObject").resolves({});
+        awsMock.mockService("S3", "headObject").resolves({
+            ContentType: "image/png",
+            Metadata: { cache: "forever" },
+        });
         // The obsolete file already carries unrelated tags (one needing URL-encoding) plus a stale
         // Obsolete tag that should be dropped before re-adding Obsolete=true.
         awsMock.mockService("S3", "getObjectTagging").resolves({
@@ -88,8 +134,14 @@ describe("s3 sync", () => {
         expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
             Bucket: "bucket-name",
             Key: "assets/old.png",
+            MetadataDirective: "REPLACE",
+            Metadata: {
+                cache: "forever",
+            },
             TaggingDirective: "REPLACE",
             Tagging: "Cache=forever&Team=a%2Fb%20c&Obsolete=true",
         });
+        const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+        expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
     });
 });

--- a/test/unit/serverSideWebsite.test.ts
+++ b/test/unit/serverSideWebsite.test.ts
@@ -682,6 +682,10 @@ describe("server-side website", () => {
             return Promise.resolve({ TagSet: [] });
         });
         const putObjectTaggingSpy = awsMock.mockService("S3", "putObjectTagging").resolves({});
+        awsMock.mockService("S3", "headObject").resolves({
+            ContentType: "image/jpeg",
+            Metadata: { cache: "forever" },
+        });
         const copyObjectSpy = awsMock.mockService("S3", "copyObject").resolves({});
         const cloudfrontInvalidationSpy = awsMock.mockService("CloudFront", "createInvalidation");
 
@@ -724,26 +728,48 @@ describe("server-side website", () => {
         // image.jpg is obsolete: it is tagged through an in-place copy (sets the tag and resets
         // the lifecycle expiry in a single call).
         sinon.assert.calledOnce(copyObjectSpy);
-        expect(copyObjectSpy.firstCall.firstArg).toEqual({
+        expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
             Bucket: "bucket-name",
             Key: "assets/image.jpg",
             CopySource: "bucket-name/assets/image.jpg",
-            MetadataDirective: "COPY",
+            MetadataDirective: "REPLACE",
+            Metadata: {
+                cache: "forever",
+            },
+            ContentType: "image/jpeg",
             TaggingDirective: "REPLACE",
             Tagging: "Obsolete=true",
         });
+        const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+        expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
         sinon.assert.calledOnce(cloudfrontInvalidationSpy);
     });
 
-    it("should pre-upload versioned assets and only clean up obsolete assets after deploy", async () => {
+    it("should pre-upload new versioned assets and sync changed assets after deploy", async () => {
         const awsMock = mockAws();
         const website = createServerSideWebsite();
-        awsMock.mockService("S3", "listObjectsV2").resolves({
+        const listObjectsV2Spy = awsMock.mockService("S3", "listObjectsV2");
+        listObjectsV2Spy.onFirstCall().resolves({
             IsTruncated: false,
             Contents: [
                 {
                     Key: "assets/logo.png",
                     ETag: computeS3ETag(fs.readFileSync(path.join(serverSideWebsiteFixturePath, "public/logo.png"))),
+                },
+                { Key: "assets/styles.css" },
+                { Key: "assets/image.jpg" },
+            ],
+        });
+        listObjectsV2Spy.onSecondCall().resolves({
+            IsTruncated: false,
+            Contents: [
+                {
+                    Key: "assets/logo.png",
+                    ETag: computeS3ETag(fs.readFileSync(path.join(serverSideWebsiteFixturePath, "public/logo.png"))),
+                },
+                {
+                    Key: "assets/scripts.js",
+                    ETag: computeS3ETag(fs.readFileSync(path.join(serverSideWebsiteFixturePath, "public/scripts.js"))),
                 },
                 { Key: "assets/styles.css" },
                 { Key: "assets/image.jpg" },
@@ -762,14 +788,22 @@ describe("server-side website", () => {
         await website.preDeploy();
         const uploadCountAfterPreDeploy = putObjectSpy.callCount;
 
-        expect(uploadCountAfterPreDeploy).toBe(2);
+        expect(uploadCountAfterPreDeploy).toBe(1);
+        expect(putObjectSpy.firstCall.firstArg).toMatchObject({
+            Bucket: "bucket-name",
+            Key: "assets/scripts.js",
+        });
         sinon.assert.notCalled(deleteObjectsSpy);
         sinon.assert.notCalled(putObjectTaggingSpy);
         sinon.assert.notCalled(cloudfrontInvalidationSpy);
 
         await website.postDeploy();
 
-        sinon.assert.callCount(putObjectSpy, uploadCountAfterPreDeploy);
+        sinon.assert.callCount(putObjectSpy, uploadCountAfterPreDeploy + 1);
+        expect(putObjectSpy.secondCall.firstArg).toMatchObject({
+            Bucket: "bucket-name",
+            Key: "assets/styles.css",
+        });
         sinon.assert.notCalled(deleteObjectsSpy);
         expect(getObjectTaggingSpy.getCalls().map((call) => call.firstArg as unknown)).toEqual(
             expect.arrayContaining([
@@ -789,9 +823,13 @@ describe("server-side website", () => {
         expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
             Bucket: "bucket-name",
             Key: "assets/image.jpg",
+            MetadataDirective: "REPLACE",
+            Metadata: {},
             TaggingDirective: "REPLACE",
             Tagging: "Obsolete=true",
         });
+        const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+        expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
         // The assets uploaded during preDeploy warrant a cache invalidation, deferred to postDeploy.
         sinon.assert.calledOnce(cloudfrontInvalidationSpy);
     });
@@ -838,9 +876,13 @@ describe("server-side website", () => {
         expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
             Bucket: "bucket-name",
             Key: "assets/image.jpg",
+            MetadataDirective: "REPLACE",
+            Metadata: {},
             TaggingDirective: "REPLACE",
             Tagging: "Obsolete=true",
         });
+        const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+        expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
         // The assets uploaded during the full post-deploy sync warrant a cache invalidation.
         sinon.assert.calledOnce(cloudfrontInvalidationSpy);
     });

--- a/test/utils/versionedAssets.ts
+++ b/test/utils/versionedAssets.ts
@@ -33,6 +33,10 @@ export function mockVersionedAssetSync({
             { Key: obsoleteKey },
         ],
     });
+    awsMock.mockService("S3", "headObject").resolves({
+        ContentType: "image/png",
+        Metadata: { cache: "forever" },
+    });
 
     return {
         putObjectSpy: awsMock.mockService("S3", "putObject"),
@@ -105,9 +109,16 @@ export function expectVersionedAssetSync({
     expect(copyObjectSpy.firstCall.firstArg).toMatchObject({
         Bucket: "bucket-name",
         Key: obsoleteKey,
+        MetadataDirective: "REPLACE",
+        Metadata: {
+            cache: "forever",
+        },
+        ContentType: "image/png",
         TaggingDirective: "REPLACE",
         // The pre-existing Cache tag is preserved alongside the added Obsolete tag.
         Tagging: "Cache=forever&Obsolete=true",
     });
+    const copyObjectMetadata = (copyObjectSpy.firstCall.firstArg as { Metadata: Record<string, string> }).Metadata;
+    expect(typeof copyObjectMetadata["lift-obsolete-at"]).toBe("string");
     sinon.assert.calledOnce(cloudfrontInvalidationSpy);
 }


### PR DESCRIPTION
- Upload only missing assets during versioned asset pre-deploy.
- Run the full asset sync after deploy so existing files update only after code deploy succeeds.
- Fix obsolete-asset self-copy
