### PR TITLE
Add missing S3 permissions for the storage construct

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,16 @@ For exemple, the [`storage` construct](storage.md) will happen the following per
 - `s3:GetObject`
 - `s3:DeleteObject`
 - `s3:ListBucket`
+- `s3:GetObjectAcl`
+- `s3:PutObjectAcl`
+- `s3:GetObjectTagging`
+- `s3:PutObjectTagging`
+- `s3:DeleteObjectTagging`
+- `s3:GetObjectAttributes`
+- `s3:AbortMultipartUpload`
+- `s3:ListMultipartUploadParts`
+- `s3:ListBucketMultipartUploads`
+- `s3:RestoreObject`
 
 You can use the `automaticPermissions` options if you want to opt out of this default behavior. This can be especially useful for production environment where you want to provision fined-grained permissions based on your actual usage of the construct - i.e. you may want to only read from the bucket provisionned uisng the `storage` construct.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -33,7 +33,21 @@ provider:
         role:
             statements:
                 -   Effect: Allow
-                    Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"]
+                    Action:
+                        - s3:PutObject
+                        - s3:GetObject
+                        - s3:DeleteObject
+                        - s3:ListBucket
+                        - s3:GetObjectAcl
+                        - s3:PutObjectAcl
+                        - s3:GetObjectTagging
+                        - s3:PutObjectTagging
+                        - s3:DeleteObjectTagging
+                        - s3:GetObjectAttributes
+                        - s3:AbortMultipartUpload
+                        - s3:ListMultipartUploadParts
+                        - s3:ListBucketMultipartUploads
+                        - s3:RestoreObject
                     Resource:
                         - ${construct:avatars.bucketArn}
                         - Fn::Join: ['', ['${construct:avatars.bucketArn}', '/*']]

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -130,7 +130,7 @@ constructs:
         allowAcl: true
 ```
 
-This sets the S3 bucket's [Object Ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to `BucketOwnerPreferred`. ACL IAM permissions are granted automatically on all storage buckets so libraries can inspect or write ACL metadata when needed.
+This sets the S3 bucket's [Object Ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to `BucketOwnerPreferred`.
 
 ### CORS
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -62,7 +62,7 @@ _How it works: the `${construct:avatars.bucketName}` variable will automatically
 
 ## Permissions
 
-By default, all the Lambda functions deployed in the same `serverless.yml` file **will be allowed to read/write into the bucket**.
+By default, all the Lambda functions deployed in the same `serverless.yml` file **will be allowed to read/write into the bucket** and use common S3 object features such as ACLs, tags, multipart uploads, object attributes, and restores.
 
 In the example below, there are no IAM permissions to set up: `myFunction` will be allowed to read and write into the `avatars` bucket.
 
@@ -130,7 +130,7 @@ constructs:
         allowAcl: true
 ```
 
-This sets the S3 bucket's [Object Ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to `BucketOwnerPreferred` and grants `s3:GetObjectAcl` and `s3:PutObjectAcl` permissions to Lambda functions.
+This sets the S3 bucket's [Object Ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) to `BucketOwnerPreferred`. ACL IAM permissions are granted automatically on all storage buckets so libraries can inspect or write ACL metadata when needed.
 
 ### CORS
 

--- a/src/constructs/aws/Storage.ts
+++ b/src/constructs/aws/Storage.ts
@@ -36,6 +36,23 @@ const STORAGE_DEFAULTS: Omit<Required<FromSchema<typeof STORAGE_DEFINITION>>, "a
     lifecycleRules: [],
 };
 
+const STORAGE_IAM_ACTIONS = [
+    "s3:PutObject",
+    "s3:GetObject",
+    "s3:DeleteObject",
+    "s3:ListBucket",
+    "s3:GetObjectAcl",
+    "s3:PutObjectAcl",
+    "s3:GetObjectTagging",
+    "s3:PutObjectTagging",
+    "s3:DeleteObjectTagging",
+    "s3:GetObjectAttributes",
+    "s3:AbortMultipartUpload",
+    "s3:ListMultipartUploadParts",
+    "s3:ListBucketMultipartUploads",
+    "s3:RestoreObject",
+];
+
 function capitalizeFirstLetter(str: string): string {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
@@ -214,13 +231,8 @@ export class Storage extends AwsConstruct {
     }
 
     permissions(): PolicyStatement[] {
-        const actions = ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"];
-        if (this.allowAcl) {
-            actions.push("s3:GetObjectAcl", "s3:PutObjectAcl");
-        }
-
         return [
-            new PolicyStatement(actions, [
+            new PolicyStatement(STORAGE_IAM_ACTIONS, [
                 this.bucket.bucketArn,
                 Stack.of(this).resolve(Fn.join("/", [this.bucket.bucketArn, "*"])),
             ]),

--- a/test/unit/permissions.test.ts
+++ b/test/unit/permissions.test.ts
@@ -18,6 +18,14 @@ function expectLiftStorageStatementIsAdded(cfTemplate: CfTemplate) {
                     "s3:ListBucket",
                     "s3:GetObjectAcl",
                     "s3:PutObjectAcl",
+                    "s3:GetObjectTagging",
+                    "s3:PutObjectTagging",
+                    "s3:DeleteObjectTagging",
+                    "s3:GetObjectAttributes",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:RestoreObject",
                 ],
             }),
         ])
@@ -110,7 +118,7 @@ describe("permissions", () => {
         expectLiftStorageStatementIsAdded(cfTemplate);
     });
 
-    it("should not include ACL permissions when allowAcl is not set", async () => {
+    it("should include object-management permissions when allowAcl is not set", async () => {
         const { cfTemplate } = await runServerless({
             fixture: "permissions",
             configExt: pluginConfigExt,
@@ -125,7 +133,22 @@ describe("permissions", () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     Effect: "Allow",
-                    Action: ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
+                    Action: [
+                        "s3:PutObject",
+                        "s3:GetObject",
+                        "s3:DeleteObject",
+                        "s3:ListBucket",
+                        "s3:GetObjectAcl",
+                        "s3:PutObjectAcl",
+                        "s3:GetObjectTagging",
+                        "s3:PutObjectTagging",
+                        "s3:DeleteObjectTagging",
+                        "s3:GetObjectAttributes",
+                        "s3:AbortMultipartUpload",
+                        "s3:ListMultipartUploadParts",
+                        "s3:ListBucketMultipartUploads",
+                        "s3:RestoreObject",
+                    ],
                 }),
             ])
         );


### PR DESCRIPTION
Expands the storage construct's automatic S3 IAM permissions to cover ACLs, object tagging, object attributes, multipart uploads, and restores.

These are permissions that an application may need to interact with the bucket, that makes sense to add them to the list.