### PR TITLE
Fix storage public URL variable

### DIFF
--- a/src/constructs/aws/Storage.ts
+++ b/src/constructs/aws/Storage.ts
@@ -224,7 +224,7 @@ export class Storage extends AwsConstruct {
 
         if (this.publicObjects !== undefined) {
             // Base URL of the bucket (no key), e.g. https://<bucket>.s3.<region>.amazonaws.com
-            variables.publicUrl = this.bucket.virtualHostedUrlForObject();
+            variables.publicUrl = Fn.join("", ["https://", this.bucket.bucketRegionalDomainName]);
         }
 
         return variables;

--- a/test/fixtures/variables/serverless.yml
+++ b/test/fixtures/variables/serverless.yml
@@ -14,6 +14,7 @@ functions:
         environment:
             VAR1: ${construct:bar.queueUrl}
             CUSTOM_VAR: ${self:custom.variable}
+            PUBLIC_URL: ${construct:bucket.publicUrl}
 
 constructs:
     bar:
@@ -34,6 +35,7 @@ constructs:
         certificate: ${custom-arn:foo}
     bucket:
         type: storage
+        publicPath: public
 
 resources:
     Resources:

--- a/test/unit/variables.test.ts
+++ b/test/unit/variables.test.ts
@@ -18,6 +18,9 @@ describe("variables", () => {
         expect(cfTemplate.Resources.FooLambdaFunction).toHaveProperty("Properties.Environment.Variables.CUSTOM_VAR", {
             Ref: "bucketBucketF19722A9",
         });
+        expect(cfTemplate.Resources.FooLambdaFunction).toHaveProperty("Properties.Environment.Variables.PUBLIC_URL", {
+            "Fn::Join": ["", ["https://", { "Fn::GetAtt": ["bucketBucketF19722A9", "RegionalDomainName"] }]],
+        });
     });
 
     it("should resolve variables in constructs", async () => {


### PR DESCRIPTION
Fixes the storage construct publicUrl variable so it resolves to a CloudFormation join instead of stringifying unresolved tokens.